### PR TITLE
diner_l4: Fix player 4 last_game address

### DIFF
--- a/diner_l4.nv.json
+++ b/diner_l4.nv.json
@@ -31,7 +31,7 @@
     {
       "encoding": "bcd",
       "length": 4,
-      "start": 556
+      "start": 524
     }
   ],
   "high_scores": [


### PR DESCRIPTION
Previous address seems to (sometimes) contain a dupe of Highscore 

Zip contains 2 nvram files:
diner_l4.0.nv should have 0 score. Previous address gives `'Player 4': 6500000}`. 
diner_l4.4p0.nv should have the scores in the attached image.



[diner_l4_samples.zip](https://github.com/tomlogic/pinmame-nvram-maps/files/12111413/diner_l4_samples.zip)
![diner_l4 4p0](https://github.com/tomlogic/pinmame-nvram-maps/assets/775439/27f9bf40-7c27-47ed-8d1f-1fc3c81671c6)

