### PR TITLE
Bally MPU AS-2518-35: initial maps

### DIFF
--- a/blakpyra.nv.json
+++ b/blakpyra.nv.json
@@ -1,0 +1,208 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "Black Pyramid (Bally 1984)",
+    "https://www.ipdb.org/machine.cgi?id=312",
+    "https://opdb.org/machines/228",
+    "Bally MPU AS-2518-35",
+    "7-digit score display",
+    "free play by default"
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "blakpyra"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 61,
+      "length": 2,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 72,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 79,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 86,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 93,
+      "encoding": "bcd",
+      "length": 7
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 166,
+        "encoding": "bcd",
+        "length": 7
+      }
+    }
+  ],
+  "audits": {
+    "Bookkeeping functions": {
+      "05": {
+        "label": "Current Credits",
+        "start": 173,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 40
+      },
+      "06": {
+        "label": "Total Plays (Played and Free Games)",
+        "start": 180,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "07": {
+        "label": "Total Replays (Free Games)",
+        "start": 187,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "08": {
+        "label": "Game Percentage",
+        "start": 194,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "09": {
+        "label": "Total times 'High Score To Date' is beat",
+        "start": 201,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "10": {
+        "label": "Coins Dropped thru Coin Chute #1",
+        "start": 208,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "11": {
+        "label": "Coins Dropped thru Coin Chute #2",
+        "start": 215,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "12": {
+        "label": "Coins Dropped thru Coin Chute #3",
+        "start": 222,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "13": {
+        "label": "Number of Specials awarded from Panel Specials Only",
+        "start": 229,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "14": {
+        "label": "Number of minutes of Game Play",
+        "start": 236,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "15": {
+        "label": "Number of Service Credits",
+        "start": 243,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      }
+    }
+  },
+  "adjustments": {
+    "High score functions": {
+      "01": {
+        "label": "Extra ball / Free game score level 1",
+        "start": 146,
+        "encoding": "bcd",
+        "length": 6,
+        "min": 0,
+        "max": 999000,
+        "default": 0,
+        "scale": 10,
+        "special_values": {
+          "0": "OFF"
+        },
+        "multiple_of": 10000
+      },
+      "02": {
+        "label": "Extra ball / Free game score level 2",
+        "start": 152,
+        "encoding": "bcd",
+        "length": 6,
+        "min": 0,
+        "max": 999000,
+        "default": 0,
+        "scale": 10,
+        "special_values": {
+          "0": "OFF"
+        },
+        "multiple_of": 10000
+      },
+      "03": {
+        "_note": "Increments by 10000",
+        "label": "Extra ball / Free game score level 3",
+        "start": 158,
+        "encoding": "bcd",
+        "length": 6,
+        "min": 0,
+        "max": 999000,
+        "default": 0,
+        "scale": 10,
+        "special_values": {
+          "0": "OFF"
+        },
+        "multiple_of": 10000
+      },
+      "04": {
+        "label": "High score to date",
+        "start": 166,
+        "encoding": "bcd",
+        "length": 7,
+        "min": 0,
+        "max": 9990000
+      }
+    }
+  }
+}

--- a/bmx.nv.json
+++ b/bmx.nv.json
@@ -1,0 +1,60 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "BMX (Bally 1983)",
+    "https://www.ipdb.org/machine.cgi?id=335",
+    "https://opdb.org/machines/431",
+    "Bally MPU AS-2518-35",
+    "7-digit score display"
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "bmx"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 61,
+      "length": 2,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 72,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 79,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 86,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 93,
+      "encoding": "bcd",
+      "length": 7
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 166,
+        "encoding": "bcd",
+        "length": 7
+      }
+    }
+  ]
+}

--- a/centaur.nv.json
+++ b/centaur.nv.json
@@ -1,0 +1,278 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "Centaur (Bally 1981)",
+    "https://www.ipdb.org/machine.cgi?id=476",
+    "https://opdb.org/machines/409",
+    "Bally MPU AS-2518-35",
+    "7-digit score display",
+    "centaura is the free play version.",
+    "By default the credits are not shown, set dip switch 27 to show them."
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "centaur",
+    "centaura"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 61,
+      "length": 2,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 72,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 79,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 86,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 93,
+      "encoding": "bcd",
+      "length": 7
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 166,
+        "encoding": "bcd",
+        "length": 7
+      }
+    }
+  ],
+  "audits": {
+    "Bookkeeping functions": {
+      "05": {
+        "label": "Current Credits",
+        "start": 173,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 40
+      },
+      "06": {
+        "label": "Total Plays (Played and Free Games)",
+        "start": 180,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "07": {
+        "label": "Total Replays (Free Games)",
+        "start": 187,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "08": {
+        "label": "Game Percentage",
+        "start": 194,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "09": {
+        "label": "Total times 'High Score To Date' is beat",
+        "start": 201,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "10": {
+        "label": "Coins Dropped thru Coin Chute #1",
+        "start": 208,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "11": {
+        "label": "Coins Dropped thru Coin Chute #2",
+        "start": 215,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "12": {
+        "label": "Coins Dropped thru Coin Chute #3",
+        "start": 222,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "13": {
+        "label": "Number of Specials awarded from Panel Specials Only",
+        "start": 229,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "14": {
+        "label": "Number of minutes of Game Play",
+        "start": 236,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      },
+      "15": {
+        "label": "Number of Service Credits",
+        "start": 243,
+        "length": 7,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 99999
+      }
+    }
+  },
+  "adjustments": {
+    "High score functions": {
+      "01": {
+        "label": "Extra ball / Free game score level 1",
+        "start": 146,
+        "encoding": "bcd",
+        "length": 6,
+        "min": 0,
+        "max": 999000,
+        "default": 0,
+        "scale": 10,
+        "special_values": {
+          "0": "OFF"
+        },
+        "multiple_of": 10000
+      },
+      "02": {
+        "label": "Extra ball / Free game score level 2",
+        "start": 152,
+        "encoding": "bcd",
+        "length": 6,
+        "min": 0,
+        "max": 999000,
+        "default": 0,
+        "scale": 10,
+        "special_values": {
+          "0": "OFF"
+        },
+        "multiple_of": 10000
+      },
+      "03": {
+        "_note": "Increments by 10000",
+        "label": "Extra ball / Free game score level 3",
+        "start": 158,
+        "encoding": "bcd",
+        "length": 6,
+        "min": 0,
+        "max": 999000,
+        "default": 0,
+        "scale": 10,
+        "special_values": {
+          "0": "OFF"
+        },
+        "multiple_of": 10000
+      },
+      "04": {
+        "label": "High score to date",
+        "start": 166,
+        "encoding": "bcd",
+        "length": 7,
+        "min": 0,
+        "max": 9990000
+      }
+    },
+    "Game adjustments": {
+      "16": {
+        "label": "High Score award #1",
+        "start": 250,
+        "length": 1,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 3,
+        "special_values": {
+          "0": "No Award",
+          "1": "Novelty",
+          "2": "Extra Ball",
+          "3": "Replay"
+        }
+      },
+      "17": {
+        "label": "High Score award #2",
+        "start": 251,
+        "length": 1,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 3,
+        "special_values": {
+          "0": "No Award",
+          "1": "No Award",
+          "2": "Extra Ball",
+          "3": "Replay"
+        }
+      },
+      "18": {
+        "label": "???",
+        "start": 252,
+        "length": 1,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 3
+      },
+      "19": {
+        "label": "High Score to date or over 10.000.000 score feature",
+        "start": 253,
+        "length": 1,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 3,
+        "special_values": {
+          "0": "No Award",
+          "1": "One Credit",
+          "2": "Two Credits",
+          "3": "Three Credits"
+        }
+      },
+      "20": {
+        "label": "???",
+        "start": 254,
+        "length": 1,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 15
+      },
+      "21": {
+        "label": "???",
+        "start": 255,
+        "length": 1,
+        "encoding": "bcd",
+        "min": 0,
+        "max": 15
+      }
+    }
+  }
+}

--- a/embryond.nv.json
+++ b/embryond.nv.json
@@ -1,0 +1,61 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "Embryon (Bally 1981)",
+    "https://www.ipdb.org/machine.cgi?id=783",
+    "https://opdb.org/machines/1695",
+    "Bally MPU AS-2518-35",
+    "7-digit score display"
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "embryond",
+    "embryon"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 61,
+      "length": 2,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 72,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 79,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 86,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 93,
+      "encoding": "bcd",
+      "length": 7
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 166,
+        "encoding": "bcd",
+        "length": 7
+      }
+    }
+  ]
+}

--- a/fathom.nv.json
+++ b/fathom.nv.json
@@ -1,0 +1,60 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "Fathom (Bally 1981)",
+    "https://www.ipdb.org/machine.cgi?id=829",
+    "https://opdb.org/machines/1480",
+    "Bally MPU AS-2518-35",
+    "7-digit score display"
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "fathom"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 61,
+      "length": 2,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 72,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 79,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 86,
+      "encoding": "bcd",
+      "length": 7
+    },
+    {
+      "start": 93,
+      "encoding": "bcd",
+      "length": 7
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 166,
+        "encoding": "bcd",
+        "length": 7
+      }
+    }
+  ]
+}

--- a/hglbtrtb.nv.json
+++ b/hglbtrtb.nv.json
@@ -1,0 +1,66 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "Harlem Globetrotters On Tour (Bally 1979)",
+    "https://www.ipdb.org/machine.cgi?id=1125",
+    "https://opdb.org/machines/1742",
+    "Bally MPU AS-2518-35",
+    "7-digit score display (but internally 6-digit)",
+    "hglbtrtb is on free play by default"
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "hglbtrtb"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 57,
+      "length": 1,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 61,
+      "encoding": "bcd",
+      "length": 6,
+      "scale": 10
+    },
+    {
+      "start": 67,
+      "encoding": "bcd",
+      "length": 6,
+      "scale": 10
+    },
+    {
+      "start": 73,
+      "encoding": "bcd",
+      "length": 6,
+      "scale": 10
+    },
+    {
+      "start": 79,
+      "encoding": "bcd",
+      "length": 6,
+      "scale": 10
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 171,
+        "encoding": "bcd",
+        "length": 6,
+        "scale": 10
+      }
+    }
+  ]
+}

--- a/kissc.nv.json
+++ b/kissc.nv.json
@@ -1,0 +1,60 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "KISS (Bally 1979)",
+    "https://www.ipdb.org/machine.cgi?id=1386",
+    "https://opdb.org/machines/1225",
+    "Bally MPU AS-2518-35",
+    "rev. 3 6-digit score display"
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "kissc"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 57,
+      "length": 1,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 60,
+      "encoding": "bcd",
+      "length": 6
+    },
+    {
+      "start": 66,
+      "encoding": "bcd",
+      "length": 6
+    },
+    {
+      "start": 72,
+      "encoding": "bcd",
+      "length": 6
+    },
+    {
+      "start": 78,
+      "encoding": "bcd",
+      "length": 6
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 207,
+        "encoding": "bcd",
+        "length": 6
+      }
+    }
+  ]
+}

--- a/paragon.nv.json
+++ b/paragon.nv.json
@@ -1,0 +1,60 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "Paragon (Bally 1979)",
+    "https://www.ipdb.org/machine.cgi?id=1755",
+    "https://opdb.org/machines/296",
+    "Bally MPU AS-2518-35",
+    "6-digit score display"
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "paragon"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 57,
+      "length": 1,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 61,
+      "encoding": "bcd",
+      "length": 6
+    },
+    {
+      "start": 67,
+      "encoding": "bcd",
+      "length": 6
+    },
+    {
+      "start": 73,
+      "encoding": "bcd",
+      "length": 6
+    },
+    {
+      "start": 74,
+      "encoding": "bcd",
+      "length": 6
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 207,
+        "encoding": "bcd",
+        "length": 6
+      }
+    }
+  ]
+}

--- a/startreb.nv.json
+++ b/startreb.nv.json
@@ -1,0 +1,65 @@
+{
+  "_notes": [
+    "Compiled by Francis De Brabandere.",
+    "Star Trek (Bally 1979)",
+    "https://www.ipdb.org/machine.cgi?id=2355",
+    "https://opdb.org/machines/473",
+    "Bally MPU AS-2518-35",
+    "7-digit score display (but internally 6-digit)"
+  ],
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "little",
+  "_nibble": "high",
+  "_roms": [
+    "startreb"
+  ],
+  "_fileformat": 0.4,
+  "_version": 0.1,
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 57,
+      "length": 1,
+      "encoding": "bcd"
+    }
+  },
+  "last_game": [
+    {
+      "start": 60,
+      "encoding": "bcd",
+      "length": 6,
+      "scale": 10
+    },
+    {
+      "start": 66,
+      "encoding": "bcd",
+      "length": 6,
+      "scale": 10
+    },
+    {
+      "start": 72,
+      "encoding": "bcd",
+      "length": 6,
+      "scale": 10
+    },
+    {
+      "start": 78,
+      "encoding": "bcd",
+      "length": 6,
+      "scale": 10
+    }
+  ],
+  "high_scores": [
+    {
+      "label": "High Score",
+      "short_label": "HS",
+      "score": {
+        "start": 207,
+        "encoding": "bcd",
+        "length": 6,
+        "scale": 10
+      }
+    }
+  ]
+}


### PR DESCRIPTION
First batch

Was so free to set `_fileformat` to `0.4` and use `_nibble`, so this has to wait for #60 

Centaur is complete, the rest mainly high scores