### PR TITLE
fix: invalid checksum8 ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ Keys that don't start with an underscore typically have groups of
 
 The objects used for the last two entries in the file are
 slightly different from the other descriptors.  They have the required
-`start` field, require either an `end` (preferred) or `length`, and
+`start` field, require either an inclusive `end` (preferred) or `length`, and
 `label` is optional.  They introduce an optional `groupings` key used to
-treat a single descriptor as a list of equally-sized groupings.
+treat a single descriptor as a list of groupings-sized ranges. 
 
 (On WPC games, the audits are a series of 6-byte entries, each with an
 8-bit checksum as the last byte.)

--- a/fh_l9.nv.json
+++ b/fh_l9.nv.json
@@ -583,7 +583,7 @@
   "checksum8": [
     {
       "start": 6161,
-      "end": 6881,
+      "end": 6880,
       "groupings": 6,
       "label": "Audits"
     }

--- a/hs_l4.nv.json
+++ b/hs_l4.nv.json
@@ -975,7 +975,7 @@
   "checksum8": [
     {
       "start": 1700,
-      "end": 1828,
+      "end": 1827,
       "groupings": 4,
       "label": "Audits"
     },

--- a/tsptr_l3.nv.json
+++ b/tsptr_l3.nv.json
@@ -1002,7 +1002,7 @@
   "checksum8": [
     {
       "start": 1700,
-      "end": 1802,
+      "end": 1803,
       "groupings": 4,
       "label": "Audits"
     }


### PR DESCRIPTION
Ranges are inclusive and should be divisible by the groupings.