### PR TITLE
robo_a34.nv: fix adjustment min/max/default that was scaled

### DIFF
--- a/robo_a34.nv.json
+++ b/robo_a34.nv.json
@@ -406,9 +406,9 @@
         "label": "Reset Every",
         "start": 8005,
         "encoding": "int",
-        "min": 100,
-        "max": 900,
-        "default": 700,
+        "min": 1,
+        "max": 9,
+        "default": 7,
         "scale": 100
       },
       "35": {


### PR DESCRIPTION
closes #62 