### PR TITLE
Add maps support for DIP switch settings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for file formatting issues or outdated index.json
         run: |
-          tools/reformat-map.sh *.json
+          shopt -s globstar
+          tools/reformat-map.sh **/*.nv.json
           if [[ -n $(git status --porcelain) ]]; then
               git status
               echo "Some maps are formatted incorrectly. Please check the README on how to reformat your files."

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ not the contents of the corresponding NVRAM file.
 The map file contains objects describing sections of the `.nv` file and
 how to interpret them.  They're comprised of the following key/value pairs:
 
-- **_note**: A note for someone maintaining the file; not displayed when
+- **_notes**: Notes for someone maintaining the file; not displayed when
   processing an NVRAM file.
 
 - **encoding** _(required)_ must be one of the following:

--- a/README.md
+++ b/README.md
@@ -329,10 +329,10 @@ Keys that don't start with an underscore typically have groups of
 ### DIP Switches
 
 PinMAME stores DIP Switch values in the last six bytes of the `.nv` file.
-The first byte represents SW1 to SW8, with SW1 in bit 0.  The second byte
-is SW9 to SW16, etc.  The fifth and sixth bytes are typically used for
-switches on sound boards.  These map files represent them as SW33 to SW40
-and SW41 to SW48.
+The first byte represents SW1 to SW8, with SW1 in the least significant bit.
+The second byte is SW9 to SW16, etc.  The fifth and sixth bytes are typically
+used for switches on sound boards.  These map files reference them as SW33 to
+SW40 and SW41 to SW48.
 
 The `dip_switches` section of the file describes the settings for individual
 switches or groups of switches, stored as a dictionary with a key that is

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ not the contents of the corresponding NVRAM file.
   Modified map files, or maps created using an existing map as a starting
   point are also covered by that license.
 - **_notes**: Notes about the file, possibly indicating who created it or
-  portions of the file that may not be entirely correct.
+  portions of the file that may not be entirely correct.  Can be a string
+  or an array of strings.
 - **_endian**: Set to either `"big"` or `"little"` to indicate the default
   byte order of multi-byte values.  Defaults to `"big"`.
   Refers to which end of the number is stored first.  For example, a
@@ -159,7 +160,7 @@ The map file contains objects describing sections of the `.nv` file and
 how to interpret them.  They're comprised of the following key/value pairs:
 
 - **_notes**: Notes for someone maintaining the file; not displayed when
-  processing an NVRAM file.
+  processing an NVRAM file.  Can be a string or an array of strings.
 
 - **encoding** _(required)_ must be one of the following:
   - `"enum"`: An enumerated type where the byte at `start` is used as an

--- a/index.json
+++ b/index.json
@@ -167,7 +167,7 @@
   "tz_92": "maps/williams/wpc/tz_92.nv.json",
   "tz_94ch": "maps/williams/wpc/tz_94h.nv.json",
   "tz_94h": "maps/williams/wpc/tz_94h.nv.json",
-  "victory": "maps/gottlieb/gottlieb_80b-2.nv.json",
+  "victory": "maps/gottlieb/victory.nv.json",
   "vrkon_l1": "maps/williams/williams.system7.nv.json",
   "wcs_l2": "maps/williams/wpc/wcs_l2.nv.json",
   "wd_12": "maps/williams/wpc/wd_12.nv.json",

--- a/maps/bally/as-2518-35/blakpyra.nv.json
+++ b/maps/bally/as-2518-35/blakpyra.nv.json
@@ -181,7 +181,7 @@
         "multiple_of": 10000
       },
       "03": {
-        "_note": "Increments by 10000",
+        "_notes": "Increments by 10000",
         "label": "Extra ball / Free game score level 3",
         "start": 158,
         "encoding": "bcd",

--- a/maps/bally/as-2518-35/centaur.nv.json
+++ b/maps/bally/as-2518-35/centaur.nv.json
@@ -183,7 +183,7 @@
         "multiple_of": 10000
       },
       "03": {
-        "_note": "Increments by 10000",
+        "_notes": "Increments by 10000",
         "label": "Extra ball / Free game score level 3",
         "start": 158,
         "encoding": "bcd",
@@ -245,7 +245,7 @@
       },
       "19": {
         "label": "High Score to date or over 10.000.000 score feature",
-        "_note": "Looking at this field as an int the default is 15",
+        "_notes": "Looking at this field as an int the default is 15",
         "start": 253,
         "length": 1,
         "encoding": "bcd",

--- a/maps/bally/as-2518-35/dollyptb.nv.json
+++ b/maps/bally/as-2518-35/dollyptb.nv.json
@@ -179,7 +179,7 @@
         "multiple_of": 10000
       },
       "03": {
-        "_note": "Increments by 10000",
+        "_notes": "Increments by 10000",
         "label": "Extra ball / Free game score level 3",
         "start": 165,
         "encoding": "bcd",

--- a/maps/bally/as-2518-35/eballdlx.nv.json
+++ b/maps/bally/as-2518-35/eballdlx.nv.json
@@ -189,7 +189,7 @@
         "multiple_of": 10000
       },
       "03": {
-        "_note": "Increments by 10000",
+        "_notes": "Increments by 10000",
         "label": "Extra ball / Free game score level 3",
         "start": 158,
         "encoding": "bcd",
@@ -281,7 +281,7 @@
       },
       "22": {
         "label": "Backbox Deluxe Feature",
-        "_note": "default value of 15, even if that is not in the range",
+        "_notes": "default value of 15, even if that is not in the range",
         "start": 141,
         "length": 1,
         "encoding": "int",

--- a/maps/bally/as-2518-35/hglbtrtb.nv.json
+++ b/maps/bally/as-2518-35/hglbtrtb.nv.json
@@ -178,7 +178,7 @@
         "multiple_of": 10000
       },
       "03": {
-        "_note": "Increments by 10000",
+        "_notes": "Increments by 10000",
         "label": "Extra ball / Free game score level 3",
         "start": 165,
         "encoding": "bcd",

--- a/maps/gottlieb/gottlieb_80b-2.nv.json
+++ b/maps/gottlieb/gottlieb_80b-2.nv.json
@@ -7,6 +7,7 @@
     "If a value differs in all three locations, it's replaced with a default value.",
     "Note that offsets 0xF8 through 0xFC are checksums of each of the high scores.",
     "Appears to work for all System 80B S2/S3 games.",
+    "Note that victory moved to its own map to include dip switch definitions.",
     "Untested: diamond, excaliba, hotshots, nmoves"
   ],
   "_copyright": "Copyright (C) 2024 by Tom Collins <tom@tomlogic.com>",
@@ -19,7 +20,6 @@
     "excalibr",
     "robowars",
     "txsector",
-    "victory",
     "badgirls",
     "bighouse",
     "bonebstr",

--- a/maps/gottlieb/victory.nv.json
+++ b/maps/gottlieb/victory.nv.json
@@ -1,0 +1,463 @@
+{
+  "_notes": [
+    "Compiled by Tom Collins.",
+    "Modified version of gottlieb_80b-2.nv.json with dip switch entries."
+  ],
+  "_copyright": "Copyright (C) 2024 by Tom Collins <tom@tomlogic.com>",
+  "_license": "GNU Lesser General Public License v3.0",
+  "_endian": "big",
+  "_nibble": "low",
+  "_roms": [
+    "victory"
+  ],
+  "_fileformat": 0.5,
+  "_version": 0.1,
+  "_values": {
+    "off_on": [
+      "off",
+      "on"
+    ],
+    "_notes": [
+      "pricing: X@Y credit incentives: X credits given after Y coins"
+    ],
+    "pricing": [
+      "1 credit/coin",
+      "2 credits/coin",
+      "3 credits/coin",
+      "4 credits/coin",
+      "5 credits/coin",
+      "6 credits/coin",
+      "7 credits/coin",
+      "8 credits/coin",
+      "9 credits/coin",
+      "10 credits/coin",
+      "1 credit/2 coins",
+      "2 credits/2 coins",
+      "3 credits/2 coins",
+      "4 credits/2 coins",
+      "5 credits/2 coins",
+      "6 credits/2 coins",
+      "7 credits/2 coins",
+      "8 credits/2 coins",
+      "9 credits/2 coins",
+      "10 credits/2 coins",
+      "1 credit/3 coins",
+      "2 credits/3 coins",
+      "1 credit/4 coins",
+      "3 credits/4 coins",
+      "9 credits/coin",
+      "incentive: 1@1, 1@2",
+      "incentive: 1@2, 1@3, 1@4",
+      "incentive: 1@2, 2@4",
+      "incentive: 1@1, 1@2, 1@3, 2@4",
+      "incentive: 1@1, 2@2, 1@3, 3@4",
+      "incentive: 1@1, 2@2, 2@3, 2@4",
+      "incentive: 1@3, 1@5"
+    ]
+  },
+  "game_state": {
+    "credits": {
+      "label": "Credits",
+      "start": 57,
+      "encoding": "bcd",
+      "length": 2
+    }
+  },
+  "high_scores": [
+    {
+      "label": "High Score #1",
+      "short_label": "1st",
+      "initials": {
+        "start": 183,
+        "encoding": "ch",
+        "default": "\u0000\u0000\u0000",
+        "length": 6
+      },
+      "score": {
+        "start": 189,
+        "encoding": "bcd",
+        "length": 7,
+        "scale": 10
+      }
+    },
+    {
+      "label": "High Score #2",
+      "short_label": "2nd",
+      "initials": {
+        "start": 196,
+        "encoding": "ch",
+        "default": "\u0000\u0000\u0000",
+        "length": 6
+      },
+      "score": {
+        "start": 202,
+        "encoding": "bcd",
+        "length": 7,
+        "scale": 10
+      }
+    },
+    {
+      "label": "High Score #3",
+      "short_label": "3rd",
+      "initials": {
+        "start": 209,
+        "encoding": "ch",
+        "default": "\u0000\u0000\u0000",
+        "length": 6
+      },
+      "score": {
+        "start": 215,
+        "encoding": "bcd",
+        "length": 7,
+        "scale": 10
+      }
+    },
+    {
+      "label": "High Score #4",
+      "short_label": "4th",
+      "initials": {
+        "start": 222,
+        "encoding": "ch",
+        "default": "\u0000\u0000\u0000",
+        "length": 6
+      },
+      "score": {
+        "start": 228,
+        "encoding": "bcd",
+        "length": 7,
+        "scale": 10
+      }
+    },
+    {
+      "label": "High Score #5",
+      "short_label": "5th",
+      "initials": {
+        "start": 235,
+        "encoding": "ch",
+        "default": "\u0000\u0000\u0000",
+        "length": 6
+      },
+      "score": {
+        "start": 241,
+        "encoding": "bcd",
+        "length": 7,
+        "scale": 10
+      }
+    }
+  ],
+  "audits": {
+    "Bookkeeping": {
+      "01": {
+        "label": "Left Chute Coins",
+        "start": 0,
+        "encoding": "bcd",
+        "length": 4
+      },
+      "02": {
+        "label": "Right Chute Coins",
+        "start": 4,
+        "encoding": "bcd",
+        "length": 4
+      },
+      "03": {
+        "label": "Center Chute Coins",
+        "start": 8,
+        "encoding": "bcd",
+        "length": 4
+      },
+      "04": {
+        "label": "Total Plays",
+        "start": 12,
+        "encoding": "bcd",
+        "length": 4
+      },
+      "05": {
+        "label": "Total Replays",
+        "start": 16,
+        "encoding": "bcd",
+        "length": 4
+      },
+      "07": {
+        "label": "Extra Balls",
+        "start": 20,
+        "encoding": "bcd",
+        "length": 3
+      },
+      "08": {
+        "label": "Tilts",
+        "start": 23,
+        "encoding": "bcd",
+        "length": 3
+      },
+      "09": {
+        "label": "Specials",
+        "start": 26,
+        "encoding": "bcd",
+        "length": 3
+      },
+      "10": {
+        "label": "Times HGTD Awarded",
+        "start": 29,
+        "encoding": "bcd",
+        "length": 3
+      },
+      "14": {
+        "label": "Highest Game To Date",
+        "start": 44,
+        "encoding": "bcd",
+        "length": 7,
+        "scale": 10
+      },
+      "14a": {
+        "label": "HGTD Initials",
+        "start": 38,
+        "encoding": "ch",
+        "null": "truncate",
+        "length": 6
+      },
+      "15": {
+        "label": "Game Time",
+        "suffix": " seconds",
+        "start": 32,
+        "encoding": "bcd",
+        "length": 6,
+        "scale": 10
+      }
+    }
+  },
+  "adjustments": {
+    "Standard Adjustments": {
+      "06": {
+        "label": "Replay Percentage",
+        "suffix": "%",
+        "start": 59,
+        "encoding": "bcd",
+        "length": 2
+      },
+      "11": {
+        "label": "First High Score",
+        "start": 51,
+        "encoding": "bcd",
+        "length": 2,
+        "scale": 100000
+      },
+      "12": {
+        "label": "Second High Score",
+        "start": 53,
+        "encoding": "bcd",
+        "length": 2,
+        "scale": 100000
+      },
+      "13": {
+        "label": "Third High Score",
+        "start": 55,
+        "encoding": "bcd",
+        "length": 2,
+        "scale": 100000
+      }
+    }
+  },
+  "dip_switches": {
+    "1-5": {
+      "label": "Left Coin Chute",
+      "encoding": "dipsw",
+      "offsets": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "values": "pricing"
+    },
+    "6": {
+      "label": "High Games To Date",
+      "encoding": "dipsw",
+      "offsets": [
+        6
+      ],
+      "values": [
+        "no effect",
+        "reset #2-#5 on power off"
+      ]
+    },
+    "7": {
+      "label": "Attract Mode Sound",
+      "encoding": "dipsw",
+      "offsets": [
+        7
+      ],
+      "values": "off_on"
+    },
+    "8": {
+      "label": "Auto-Percentage Control",
+      "encoding": "dipsw",
+      "offsets": [
+        8
+      ],
+      "values": [
+        "Disabled (normal high score mode)",
+        "Enabled"
+      ]
+    },
+    "9-13": {
+      "label": "Right Coin Chute",
+      "encoding": "dipsw",
+      "offsets": [
+        9,
+        10,
+        11,
+        12,
+        13
+      ],
+      "values": "pricing"
+    },
+    "14": {
+      "label": "Left/Right Coin Chute Control",
+      "encoding": "dipsw",
+      "offsets": [
+        14
+      ],
+      "values": [
+        "separate",
+        "same"
+      ]
+    },
+    "15-16": {
+      "label": "Maximum Credits",
+      "encoding": "dipsw",
+      "offsets": [
+        15,
+        16
+      ],
+      "values": [
+        8,
+        10,
+        15,
+        20
+      ]
+    },
+    "17-21": {
+      "label": "Center Coin Chute",
+      "encoding": "dipsw",
+      "offsets": [
+        17,
+        18,
+        19,
+        20,
+        21
+      ],
+      "values": "pricing"
+    },
+    "22": {
+      "label": "Playfield Special",
+      "encoding": "dipsw",
+      "offsets": [
+        22
+      ],
+      "values": [
+        "special",
+        "extra ball"
+      ]
+    },
+    "23-24": {
+      "label": "High Score Awards",
+      "encoding": "dipsw",
+      "offsets": [
+        23,
+        24
+      ],
+      "values": [
+        "none (not displayed)",
+        "none",
+        "2 replays",
+        "3 replays"
+      ]
+    },
+    "25": {
+      "label": "Balls/Game",
+      "encoding": "dipsw",
+      "offsets": [
+        25
+      ],
+      "values": [
+        5,
+        3
+      ]
+    },
+    "26": {
+      "label": "Match",
+      "encoding": "dipsw",
+      "offsets": [
+        26
+      ],
+      "values": "off_on"
+    },
+    "27": {
+      "label": "Replay Limit",
+      "encoding": "dipsw",
+      "offsets": [
+        27
+      ],
+      "values": [
+        "no limit",
+        1
+      ]
+    },
+    "28": {
+      "label": "Novelty",
+      "encoding": "dipsw",
+      "offsets": [
+        28
+      ],
+      "values": [
+        "normal",
+        "score 500K instead of extra ball/special"
+      ]
+    },
+    "29": {
+      "label": "Game Mode",
+      "encoding": "dipsw",
+      "offsets": [
+        29
+      ],
+      "values": [
+        "replay",
+        "extra ball"
+      ]
+    },
+    "30": {
+      "label": "3rd Coin Chute Credits",
+      "encoding": "dipsw",
+      "offsets": [
+        30
+      ],
+      "values": [
+        "no effect",
+        "add 9 credits"
+      ]
+    },
+    "31": {
+      "label": "Extra Ball Control",
+      "encoding": "dipsw",
+      "offsets": [
+        31
+      ],
+      "values": [
+        "conservative: hole value reset at end of ball; EB lamps alternate",
+        "liberal: hole value held between balls; both EB lamps lit"
+      ]
+    },
+    "32": {
+      "label": "Outlane Special",
+      "encoding": "dipsw",
+      "offsets": [
+        32
+      ],
+      "values": [
+        "conservative: outlane lit after second race completed",
+        "liberal: outlane lit after first race (qualifying heat) completed"
+      ]
+    }
+  }
+}

--- a/maps/williams/system11/hs_l4.nv.json
+++ b/maps/williams/system11/hs_l4.nv.json
@@ -59,7 +59,7 @@
     },
     "bonus": {
       "label": "Bonus",
-      "_note": "extracting value from lamp matrix col 6-8",
+      "_notes": "extracting value from lamp matrix col 6-8",
       "start": 21,
       "length": 3,
       "encoding": "bits",
@@ -92,7 +92,7 @@
     },
     "bonusX": {
       "label": "Bonus Multiplier",
-      "_note": [
+      "_notes": [
         "extracting value from lamp matrix col 8",
         "use offset to set bit 8 for base 1X"
       ],
@@ -114,7 +114,7 @@
     },
     "bonus_hold": {
       "label": "Bonus Hold",
-      "_note": "extracting value from lamp matrix col 8",
+      "_notes": "extracting value from lamp matrix col 8",
       "start": 23,
       "mask": "0x20",
       "encoding": "int",
@@ -224,7 +224,7 @@
       },
       "02a": {
         "label": "Replay Start",
-        "_note": "if Adj01 > 4",
+        "_notes": "if Adj01 > 4",
         "start": 1921,
         "encoding": "bcd",
         "min": 8,
@@ -234,7 +234,7 @@
       },
       "03a": {
         "label": "Replay Levels",
-        "_note": "if Adj01 > 4",
+        "_notes": "if Adj01 > 4",
         "start": 1922,
         "encoding": "bcd",
         "min": 0,
@@ -243,7 +243,7 @@
       },
       "02b": {
         "label": "Replay Level 1",
-        "_note": "if Adj01 == 4",
+        "_notes": "if Adj01 == 4",
         "start": 1921,
         "encoding": "bcd",
         "min": 0,
@@ -256,7 +256,7 @@
       },
       "03b": {
         "label": "Replay Level 2",
-        "_note": "if Adj01 == 4",
+        "_notes": "if Adj01 == 4",
         "start": 1922,
         "encoding": "bcd",
         "min": 0,
@@ -268,7 +268,7 @@
       },
       "04b": {
         "label": "Replay Level 3",
-        "_note": "if Adj01 == 4",
+        "_notes": "if Adj01 == 4",
         "start": 1923,
         "encoding": "bcd",
         "min": 0,
@@ -280,7 +280,7 @@
       },
       "05b": {
         "label": "Replay Level 4",
-        "_note": "if Adj01 == 4",
+        "_notes": "if Adj01 == 4",
         "start": 1924,
         "encoding": "bcd",
         "min": 0,
@@ -694,7 +694,7 @@
       "49a": {
         "label": "Custom Msg Line 1",
         "encoding": "ch",
-        "_note": "default uses 'o' (0x6F) for hyphen",
+        "_notes": "default uses 'o' (0x6F) for hyphen",
         "start": 1972,
         "length": 14,
         "default": "RUN THE LIGHTo"
@@ -709,7 +709,7 @@
       "49c": {
         "label": "Custom Msg Line 3",
         "encoding": "ch",
-        "_note": "default byte 0xC4 is D (0x44) with period (0x80)",
+        "_notes": "default byte 0xC4 is D (0x44) with period (0x80)",
         "start": 2000,
         "length": 14,
         "default": "AT HIGH SPEE\u00c4 "
@@ -731,7 +731,7 @@
           "",
           ""
         ],
-        "_note": "select 0/1, both show blank"
+        "_notes": "select 0/1, both show blank"
       },
       "52": {
         "label": "Unused Adjustment",

--- a/maps/williams/system11/tsptr_l3.nv.json
+++ b/maps/williams/system11/tsptr_l3.nv.json
@@ -52,7 +52,7 @@
     },
     "bonus": {
       "label": "Bonus",
-      "_note": "called Orion Bonus in game",
+      "_notes": "called Orion Bonus in game",
       "start": 231,
       "length": 2,
       "encoding": "bcd",
@@ -60,7 +60,7 @@
     },
     "bonusX": {
       "label": "Bonus Multiplier",
-      "_note": [
+      "_notes": [
         "extracting value from lamp matrix col 2",
         "use offset to set bit 8 for base 1X"
       ],
@@ -82,7 +82,7 @@
     },
     "xcel_value": {
       "label": "X-Cellerator Value",
-      "_note": "extracting value from lamp matrix col 6-7",
+      "_notes": "extracting value from lamp matrix col 6-7",
       "start": 21,
       "length": 2,
       "encoding": "bits",
@@ -143,7 +143,7 @@
         "start": 1823,
         "encoding": "ch",
         "length": 3,
-        "_note": "slash (/) used for space ( ) in all initials"
+        "_notes": "slash (/) used for space ( ) in all initials"
       },
       "score": {
         "start": 1807,
@@ -209,7 +209,7 @@
       },
       "02a": {
         "label": "Replay Start",
-        "_note": "if Adj01 > 4",
+        "_notes": "if Adj01 > 4",
         "start": 1921,
         "encoding": "bcd",
         "min": 8,
@@ -219,7 +219,7 @@
       },
       "03a": {
         "label": "Replay Levels",
-        "_note": "if Adj01 > 4",
+        "_notes": "if Adj01 > 4",
         "start": 1922,
         "encoding": "bcd",
         "min": 0,
@@ -228,7 +228,7 @@
       },
       "02b": {
         "label": "Replay Level 1",
-        "_note": "if Adj01 == 4",
+        "_notes": "if Adj01 == 4",
         "start": 1921,
         "encoding": "bcd",
         "min": 0,
@@ -241,7 +241,7 @@
       },
       "03b": {
         "label": "Replay Level 2",
-        "_note": "if Adj01 == 4",
+        "_notes": "if Adj01 == 4",
         "start": 1922,
         "encoding": "bcd",
         "min": 0,
@@ -253,7 +253,7 @@
       },
       "04b": {
         "label": "Replay Level 3",
-        "_note": "if Adj01 == 4",
+        "_notes": "if Adj01 == 4",
         "start": 1923,
         "encoding": "bcd",
         "min": 0,
@@ -265,7 +265,7 @@
       },
       "05b": {
         "label": "Replay Level 4",
-        "_note": "if Adj01 == 4",
+        "_notes": "if Adj01 == 4",
         "start": 1924,
         "encoding": "bcd",
         "min": 0,
@@ -667,7 +667,7 @@
       "49a": {
         "label": "Custom Msg Line 1",
         "encoding": "ch",
-        "_note": "set high bit for period after letter",
+        "_notes": "set high bit for period after letter",
         "start": 1972,
         "length": 16,
         "default": " G E T    M  E  "
@@ -688,7 +688,7 @@
       },
       "50": {
         "label": "Display AU 01 - 04",
-        "_note": "TODO: check enum values",
+        "_notes": "TODO: check enum values",
         "start": 1969,
         "encoding": "enum",
         "values": [

--- a/maps/williams/wpc/afm_113.nv.json
+++ b/maps/williams/wpc/afm_113.nv.json
@@ -51,7 +51,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7490,
       "encoding": "int"

--- a/maps/williams/wpc/bop_l7.nv.json
+++ b/maps/williams/wpc/bop_l7.nv.json
@@ -64,7 +64,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7405,
       "encoding": "int"

--- a/maps/williams/wpc/br_l4.nv.json
+++ b/maps/williams/wpc/br_l4.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7327,
       "encoding": "int"

--- a/maps/williams/wpc/cc_13.nv.json
+++ b/maps/williams/wpc/cc_13.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7435,
       "encoding": "int"

--- a/maps/williams/wpc/cftbl_l4.nv.json
+++ b/maps/williams/wpc/cftbl_l4.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7387,
       "encoding": "int"

--- a/maps/williams/wpc/congo_21.nv.json
+++ b/maps/williams/wpc/congo_21.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7450,
       "encoding": "int"

--- a/maps/williams/wpc/corv_21.nv.json
+++ b/maps/williams/wpc/corv_21.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7510,
       "encoding": "int"

--- a/maps/williams/wpc/cp_16.nv.json
+++ b/maps/williams/wpc/cp_16.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7500,
       "encoding": "int"
@@ -151,7 +151,7 @@
   "mode_champions": [
     {
       "label": "Pub Champ",
-      "_note": "Date follows @5965 as two 8-bit ints (month, day) and a 16-bit year",
+      "_notes": "Date follows @5965 as two 8-bit ints (month, day) and a 16-bit year",
       "initials": {
         "start": 5961,
         "encoding": "ch",

--- a/maps/williams/wpc/cv_14.nv.json
+++ b/maps/williams/wpc/cv_14.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7605,
       "encoding": "int"

--- a/maps/williams/wpc/dh_lx2.nv.json
+++ b/maps/williams/wpc/dh_lx2.nv.json
@@ -46,7 +46,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7450,
       "encoding": "int"

--- a/maps/williams/wpc/dm_dt101.nv.json
+++ b/maps/williams/wpc/dm_dt101.nv.json
@@ -112,7 +112,7 @@
       "initials": {
         "start": 6534,
         "encoding": "ch",
-        "default": "\u00FF\u00FF\u00FF",
+        "default": "\u00ff\u00ff\u00ff",
         "length": 3
       },
       "score": {

--- a/maps/williams/wpc/dm_h6.nv.json
+++ b/maps/williams/wpc/dm_h6.nv.json
@@ -50,7 +50,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7360,
       "encoding": "int"

--- a/maps/williams/wpc/dm_lx4.nv.json
+++ b/maps/williams/wpc/dm_lx4.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7320,
       "encoding": "int"

--- a/maps/williams/wpc/drac_l1.nv.json
+++ b/maps/williams/wpc/drac_l1.nv.json
@@ -45,7 +45,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7497,
       "encoding": "int"

--- a/maps/williams/wpc/dw_l2.nv.json
+++ b/maps/williams/wpc/dw_l2.nv.json
@@ -51,7 +51,7 @@
       }
     ],
     "escape_a": {
-      "_note": "0x280 and 0x288 both bitmaps for ESCAPE, 0x290 related to animating those lamps",
+      "_notes": "0x280 and 0x288 both bitmaps for ESCAPE, 0x290 related to animating those lamps",
       "label": "Escape A",
       "start": 640,
       "mask": "0x3F",
@@ -64,7 +64,7 @@
       "encoding": "raw"
     },
     "repair_a": {
-      "_note": "0x285 and 0x28d both bitmaps for REPAIR, 0x295 related to animating those lamps",
+      "_notes": "0x285 and 0x28d both bitmaps for REPAIR, 0x295 related to animating those lamps",
       "label": "Repair A",
       "start": 645,
       "mask": "0x3F",
@@ -153,7 +153,7 @@
       "label": "P1 Video Round Completed",
       "start": 2596,
       "encoding": "bcd",
-      "_note": "untested whether bcd or int!"
+      "_notes": "untested whether bcd or int!"
     },
     "video_unk": {
       "label": "P1 Video Related",
@@ -182,7 +182,7 @@
       "label": "P1 Multiball Round",
       "start": 2611,
       "encoding": "int",
-      "_note": "unverified if int or bcd"
+      "_notes": "unverified if int or bcd"
     },
     "unk5b": {
       "label": "P1 Unknown #5b",
@@ -197,7 +197,7 @@
     },
     "docs": {
       "label": "P1 Doctors",
-      "_note": "stored as groupings of 3 bits in 3 little-endian bytes, shifts left as doctors added",
+      "_notes": "stored as groupings of 3 bits in 3 little-endian bytes, shifts left as doctors added",
       "start": 2620,
       "encoding": "bits",
       "endian": "little",
@@ -233,7 +233,7 @@
       "length": 12
     },
     "playfieldX": {
-      "_note": "current player, unsure where stored between balls",
+      "_notes": "current player, unsure where stored between balls",
       "label": "Playfield X",
       "start": 2864,
       "encoding": "bcd",
@@ -251,7 +251,7 @@
       "encoding": "int"
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7497,
       "encoding": "int"

--- a/maps/williams/wpc/fh_905h.nv.json
+++ b/maps/williams/wpc/fh_905h.nv.json
@@ -49,7 +49,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7325,
       "encoding": "int"

--- a/maps/williams/wpc/fh_l9.nv.json
+++ b/maps/williams/wpc/fh_l9.nv.json
@@ -50,7 +50,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"
@@ -218,7 +218,7 @@
       }
     },
     "B.3 Standard Audits": {
-      "_note": "33 and 35 vary by game, others seem consistent",
+      "_notes": "33 and 35 vary by game, others seem consistent",
       "01": {
         "label": "Games Started",
         "start": 6275,

--- a/maps/williams/wpc/fs_lx5.nv.json
+++ b/maps/williams/wpc/fs_lx5.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"

--- a/maps/williams/wpc/ft_l5.nv.json
+++ b/maps/williams/wpc/ft_l5.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"
@@ -151,7 +151,7 @@
   "mode_champions": [
     {
       "label": "Biggest Liar",
-      "_note": "missing 'X Fish' using 1-byte int at 6058",
+      "_notes": "missing 'X Fish' using 1-byte int at 6058",
       "initials": {
         "start": 6061,
         "encoding": "ch",

--- a/maps/williams/wpc/gi_l9.nv.json
+++ b/maps/williams/wpc/gi_l9.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"

--- a/maps/williams/wpc/gw_l5.nv.json
+++ b/maps/williams/wpc/gw_l5.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"
@@ -151,7 +151,7 @@
   "mode_champions": [
     {
       "label": "Loop Champion",
-      "_note": "Unknown checksum technique",
+      "_notes": "Unknown checksum technique",
       "initials": {
         "start": 6083,
         "encoding": "ch",

--- a/maps/williams/wpc/hd_l3.nv.json
+++ b/maps/williams/wpc/hd_l3.nv.json
@@ -47,7 +47,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7318,
       "encoding": "int"

--- a/maps/williams/wpc/hurr_l2.nv.json
+++ b/maps/williams/wpc/hurr_l2.nv.json
@@ -69,7 +69,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7295,
       "encoding": "int"
@@ -157,7 +157,7 @@
   "mode_champions": [
     {
       "label": "Clown Time Record",
-      "_note": "Can't locate score (default 5M is not at 6037); unknown checksum routine.",
+      "_notes": "Can't locate score (default 5M is not at 6037); unknown checksum routine.",
       "initials": {
         "start": 6058,
         "encoding": "ch",

--- a/maps/williams/wpc/i500_11r.nv.json
+++ b/maps/williams/wpc/i500_11r.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7511,
       "encoding": "int"
@@ -223,7 +223,7 @@
         "suffix": " seconds"
       },
       "score": {
-        "_note": "Fractional 1/10s (0-9) in integer byte at 8117",
+        "_notes": "Fractional 1/10s (0-9) in integer byte at 8117",
         "start": 8116,
         "encoding": "int",
         "length": 1,

--- a/maps/williams/wpc/ij_l7.nv.json
+++ b/maps/williams/wpc/ij_l7.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7594,
       "encoding": "int"

--- a/maps/williams/wpc/jb_10r.nv.json
+++ b/maps/williams/wpc/jb_10r.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7574,
       "encoding": "int"

--- a/maps/williams/wpc/jd_l7.nv.json
+++ b/maps/williams/wpc/jd_l7.nv.json
@@ -65,7 +65,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"

--- a/maps/williams/wpc/jm_12r.nv.json
+++ b/maps/williams/wpc/jm_12r.nv.json
@@ -50,7 +50,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7320,
       "encoding": "int"
@@ -146,7 +146,7 @@
     {
       "label": "Cyberpunk",
       "short_label": "Cyberpunk",
-      "_note": "Last player to reach Powerdown (320Gb).",
+      "_notes": "Last player to reach Powerdown (320Gb).",
       "initials": {
         "start": 7878,
         "encoding": "ch",
@@ -156,7 +156,7 @@
     {
       "label": "Masters of Powerdown #1",
       "short_label": "Powerdown #1",
-      "_note": "Need to add a way to ignore entries if initials = '   '",
+      "_notes": "Need to add a way to ignore entries if initials = '   '",
       "initials": {
         "start": 7889,
         "encoding": "ch",
@@ -784,7 +784,7 @@
       },
       "10": {
         "label": "German Speech",
-        "_note": "double-check that 0=NO",
+        "_notes": "double-check that 0=NO",
         "start": 7128,
         "encoding": "enum",
         "values": [

--- a/maps/williams/wpc/jy_12.nv.json
+++ b/maps/williams/wpc/jy_12.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7440,
       "encoding": "int"

--- a/maps/williams/wpc/mb_10.nv.json
+++ b/maps/williams/wpc/mb_10.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7355,
       "encoding": "int"

--- a/maps/williams/wpc/mb_106.nv.json
+++ b/maps/williams/wpc/mb_106.nv.json
@@ -64,7 +64,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7365,
       "encoding": "int"

--- a/maps/williams/wpc/mm_10.nv.json
+++ b/maps/williams/wpc/mm_10.nv.json
@@ -52,7 +52,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7507,
       "encoding": "int"
@@ -257,7 +257,7 @@
         "encoding": "ch",
         "length": 3
       },
-      "_note": "counter for King X must be > counter for King (X+1)",
+      "_notes": "counter for King X must be > counter for King (X+1)",
       "counter": {
         "start": 8138,
         "encoding": "bcd",
@@ -423,7 +423,7 @@
       }
     },
     "B.3 Standard Audits": {
-      "_note": "33 and 35 vary by game, others seem consistent",
+      "_notes": "33 and 35 vary by game, others seem consistent",
       "01": {
         "label": "Games Started",
         "start": 6275,

--- a/maps/williams/wpc/mm_109.nv.json
+++ b/maps/williams/wpc/mm_109.nv.json
@@ -52,7 +52,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7515,
       "encoding": "int"
@@ -257,7 +257,7 @@
         "encoding": "ch",
         "length": 3
       },
-      "_note": "counter for King X must be > counter for King (X+1)",
+      "_notes": "counter for King X must be > counter for King (X+1)",
       "counter": {
         "start": 8146,
         "encoding": "bcd",
@@ -423,7 +423,7 @@
       }
     },
     "B.3 Standard Audits": {
-      "_note": "33 and 35 vary by game, others seem consistent",
+      "_notes": "33 and 35 vary by game, others seem consistent",
       "01": {
         "label": "Games Started",
         "start": 6275,

--- a/maps/williams/wpc/nbaf_31.nv.json
+++ b/maps/williams/wpc/nbaf_31.nv.json
@@ -50,7 +50,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7319,
       "encoding": "int"

--- a/maps/williams/wpc/nf_23x.nv.json
+++ b/maps/williams/wpc/nf_23x.nv.json
@@ -46,7 +46,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7460,
       "encoding": "int"

--- a/maps/williams/wpc/nf_23x.nv.json
+++ b/maps/williams/wpc/nf_23x.nv.json
@@ -138,59 +138,59 @@
       }
     }
   ],
-  "buyin_high_scores": [
+  "mode_champions": [
     {
-      "label": "First Place",
-      "short_label": "1st",
+      "label": "Buy-In High Score #1",
+      "short_label": "Buy-In #1",
       "initials": {
         "start": 8018,
         "encoding": "ch",
         "length": 3
       },
       "score": {
-        "start": 8020,
+        "start": 8021,
         "encoding": "bcd",
         "length": 6
       }
     },
     {
-      "label": "Second Place",
-      "short_label": "2nd",
+      "label": "Buy-In High Score #2",
+      "short_label": "Buy-In #2",
       "initials": {
         "start": 8027,
         "encoding": "ch",
         "length": 3
       },
       "score": {
-        "start": 8029,
+        "start": 8030,
         "encoding": "bcd",
         "length": 6
       }
     },
     {
-      "label": "Third Place",
-      "short_label": "3rd",
+      "label": "Buy-In High Score #3",
+      "short_label": "Buy-In #3",
       "initials": {
         "start": 8036,
         "encoding": "ch",
         "length": 3
       },
       "score": {
-        "start": 8038,
+        "start": 8039,
         "encoding": "bcd",
         "length": 6
       }
     },
     {
-      "label": "Fourth Place",
-      "short_label": "4th",
+      "label": "Buy-In High Score #4",
+      "short_label": "Buy-In #4",
       "initials": {
         "start": 8045,
         "encoding": "ch",
         "length": 3
       },
       "score": {
-        "start": 8047,
+        "start": 8048,
         "encoding": "bcd",
         "length": 6
       }
@@ -262,6 +262,11 @@
       "start": 7893,
       "end": 8017,
       "label": "Custom Message (2x32)"
+    },
+    {
+      "start": 8018,
+      "end": 8055,
+      "label": "Buy-In High Scores"
     }
   ]
 }

--- a/maps/williams/wpc/ngg_13.nv.json
+++ b/maps/williams/wpc/ngg_13.nv.json
@@ -63,7 +63,7 @@
       "scale": 1000000
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7418,
       "encoding": "int"

--- a/maps/williams/wpc/pop_lx5.nv.json
+++ b/maps/williams/wpc/pop_lx5.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"

--- a/maps/williams/wpc/pz_f4.nv.json
+++ b/maps/williams/wpc/pz_f4.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7295,
       "encoding": "int"
@@ -77,7 +77,7 @@
     },
     "jackpot": {
       "label": "Big Bang",
-      "_note": "duplicated at 7864",
+      "_notes": "duplicated at 7864",
       "start": 7860,
       "encoding": "bcd",
       "scale": 1000000

--- a/maps/williams/wpc/pz_l3.nv.json
+++ b/maps/williams/wpc/pz_l3.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7294,
       "encoding": "int"
@@ -77,7 +77,7 @@
     },
     "jackpot": {
       "label": "Big Bang",
-      "_note": "duplicated at 7863",
+      "_notes": "duplicated at 7863",
       "start": 7859,
       "encoding": "bcd",
       "scale": 1000000

--- a/maps/williams/wpc/rs_l6.nv.json
+++ b/maps/williams/wpc/rs_l6.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7320,
       "encoding": "int"

--- a/maps/williams/wpc/sc_091.nv.json
+++ b/maps/williams/wpc/sc_091.nv.json
@@ -57,7 +57,7 @@
       "length": 5
     },
     "credits": {
-      "_note": [
+      "_notes": [
         "1-byte credits followed by 6 bytes encoding partial/bonus credits.",
         "Location of Magic Credits unknown."
       ],

--- a/maps/williams/wpc/sc_18.nv.json
+++ b/maps/williams/wpc/sc_18.nv.json
@@ -59,7 +59,7 @@
       "length": 5
     },
     "credits": {
-      "_note": [
+      "_notes": [
         "1-byte credits followed by 6 bytes encoding partial/bonus credits.",
         "Location of Magic Credits unknown."
       ],

--- a/maps/williams/wpc/ss_15.nv.json
+++ b/maps/williams/wpc/ss_15.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7561,
       "encoding": "int"

--- a/maps/williams/wpc/sttng_l7.nv.json
+++ b/maps/williams/wpc/sttng_l7.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7320,
       "encoding": "int"

--- a/maps/williams/wpc/t2_l8.nv.json
+++ b/maps/williams/wpc/t2_l8.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"

--- a/maps/williams/wpc/taf_l5.nv.json
+++ b/maps/williams/wpc/taf_l5.nv.json
@@ -60,7 +60,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7335,
       "encoding": "int"

--- a/maps/williams/wpc/taf_l7.nv.json
+++ b/maps/williams/wpc/taf_l7.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"

--- a/maps/williams/wpc/tafg_lx3.nv.json
+++ b/maps/williams/wpc/tafg_lx3.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7335,
       "encoding": "int"

--- a/maps/williams/wpc/tom_13.nv.json
+++ b/maps/williams/wpc/tom_13.nv.json
@@ -66,7 +66,7 @@
       "encoding": "bcd"
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"
@@ -624,7 +624,7 @@
         "length": 2,
         "suffix": "M",
         "default": 1000,
-        "_note": "hidden setting?"
+        "_notes": "hidden setting?"
       },
       "06": {
         "label": "Default Buy-In HS2",
@@ -633,7 +633,7 @@
         "length": 2,
         "suffix": "M",
         "default": 980,
-        "_note": "hidden setting?"
+        "_notes": "hidden setting?"
       },
       "07": {
         "label": "Default Buy-In HS3",
@@ -642,7 +642,7 @@
         "length": 2,
         "suffix": "M",
         "default": 960,
-        "_note": "hidden setting?"
+        "_notes": "hidden setting?"
       },
       "08": {
         "label": "Default Buy-In HS4",
@@ -651,7 +651,7 @@
         "length": 2,
         "suffix": "M",
         "default": 940,
-        "_note": "hidden setting?"
+        "_notes": "hidden setting?"
       },
       "09": {
         "label": "% Spell Magic",

--- a/maps/williams/wpc/totan_14.nv.json
+++ b/maps/williams/wpc/totan_14.nv.json
@@ -46,7 +46,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7574,
       "encoding": "int"

--- a/maps/williams/wpc/ts_lx5.nv.json
+++ b/maps/williams/wpc/ts_lx5.nv.json
@@ -46,7 +46,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7504,
       "encoding": "int"
@@ -293,7 +293,7 @@
       "label": "Custom Message (2x32)"
     },
     {
-      "_note": "Initials 8062 to 8091 (unused all 0xFF), 0x00, count (0x00-0x0A), 16-bit checksum",
+      "_notes": "Initials 8062 to 8091 (unused all 0xFF), 0x00, count (0x00-0x0A), 16-bit checksum",
       "start": 8062,
       "end": 8095,
       "label": "Final Battle Immortals"

--- a/maps/williams/wpc/tz_92.nv.json
+++ b/maps/williams/wpc/tz_92.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7552,
       "encoding": "int"

--- a/maps/williams/wpc/tz_94h.nv.json
+++ b/maps/williams/wpc/tz_94h.nv.json
@@ -57,7 +57,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7578,
       "encoding": "int"

--- a/maps/williams/wpc/wcs_l2.nv.json
+++ b/maps/williams/wpc/wcs_l2.nv.json
@@ -56,7 +56,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7460,
       "encoding": "int"

--- a/maps/williams/wpc/wd_12.nv.json
+++ b/maps/williams/wpc/wd_12.nv.json
@@ -59,7 +59,7 @@
       "length": 5
     },
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7440,
       "encoding": "int"
@@ -154,7 +154,7 @@
   "mode_champions": [
     {
       "label": "The Roof Champion",
-      "_note": "Two more mode champs (at 5931 and 5945) not displayed in attract.",
+      "_notes": "Two more mode champs (at 5931 and 5945) not displayed in attract.",
       "initials": {
         "start": 5956,
         "encoding": "ch",

--- a/maps/williams/wpc/ww_l5.nv.json
+++ b/maps/williams/wpc/ww_l5.nv.json
@@ -45,7 +45,7 @@
       }
     ],
     "credits": {
-      "_note": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
+      "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
       "label": "Credits",
       "start": 7315,
       "encoding": "int"

--- a/tools/normalize-map.py
+++ b/tools/normalize-map.py
@@ -38,6 +38,10 @@ def map_convert(pairs):
 
     result = {}
     for k, v in pairs:
+        if k == '_note':
+            k = '_notes'
+
+        # set minimum file format based on appearance of certain keys
         if k == '_fileformat':
             minimum_file_format(v)
         elif k == '_nibble':

--- a/tools/normalize-map.py
+++ b/tools/normalize-map.py
@@ -53,6 +53,9 @@ def map_convert(pairs):
         elif k == 'null':
             # "null" is only valid in v0.3 and later
             minimum_file_format(0.3)
+        elif k == '_values' or (k == 'encoding' and v == 'dipsw'):
+            # "_values" appeared in v0.5 along with "dipsw" encoding
+            minimum_file_format(0.5)
 
         if k == 'packed':
             # as of v0.2, "packed" attribute deprecated in favor of "nibble"


### PR DESCRIPTION
Still a bit more work here before dip switches can be official.

- [x] Rename this file and put it in the correct location.
- [x] Remove `victory` from `gottlieb_80b-2.nv.json`.
- [x] Document `dipsw` encoding.
- [x] Document new `_values` metadata. 
- [x] Replace all `_note` tags with `_notes`.
- [x] Update index.json.