### PR TITLE
Big WPC update with game_state information

### DIFF
--- a/maps/williams/wpc/afm_113.nv.json
+++ b/maps/williams/wpc/afm_113.nv.json
@@ -69,6 +69,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 100000000
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 128,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 949,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 950,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 951,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 952,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/afm_113.nv.json
+++ b/maps/williams/wpc/afm_113.nv.json
@@ -12,7 +12,7 @@
     "afm_113b"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -70,15 +70,6 @@
       "length": 2,
       "scale": 100000000
     },
-    "playing": {
-      "label": "Playing",
-      "start": 128,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 949,
@@ -98,6 +89,15 @@
       "label": "EBs this Ball",
       "start": 952,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/bop_l7.nv.json
+++ b/maps/williams/wpc/bop_l7.nv.json
@@ -12,7 +12,7 @@
     "bop_l8"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -75,6 +75,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1038,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1041,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/br_l4.nv.json
+++ b/maps/williams/wpc/br_l4.nv.json
@@ -11,7 +11,7 @@
     "br_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/cc_13.nv.json
+++ b/maps/williams/wpc/cc_13.nv.json
@@ -11,7 +11,7 @@
     "cc_13"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 943,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 944,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 945,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/cftbl_l4.nv.json
+++ b/maps/williams/wpc/cftbl_l4.nv.json
@@ -11,7 +11,7 @@
     "cftbl_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 129,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/congo_21.nv.json
+++ b/maps/williams/wpc/congo_21.nv.json
@@ -11,7 +11,7 @@
     "congo_21"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -75,15 +75,6 @@
       "min": 0,
       "max": 31
     },
-    "playing": {
-      "label": "Playing",
-      "start": 128,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 946,
@@ -103,6 +94,15 @@
       "label": "EBs this Ball",
       "start": 949,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/congo_21.nv.json
+++ b/maps/williams/wpc/congo_21.nv.json
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 128,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/corv_21.nv.json
+++ b/maps/williams/wpc/corv_21.nv.json
@@ -11,7 +11,7 @@
     "corv_21"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/cp_16.nv.json
+++ b/maps/williams/wpc/cp_16.nv.json
@@ -11,7 +11,7 @@
     "cp_16"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/cv_14.nv.json
+++ b/maps/williams/wpc/cv_14.nv.json
@@ -11,7 +11,7 @@
     "cv_14"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 949,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 950,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 951,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 952,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/cv_20h.nv.json
+++ b/maps/williams/wpc/cv_20h.nv.json
@@ -11,7 +11,7 @@
     "cv_20h"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -68,6 +68,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 949,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 950,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 951,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 952,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/dh_lx2.nv.json
+++ b/maps/williams/wpc/dh_lx2.nv.json
@@ -12,7 +12,7 @@
     "dh_lx2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.2,
+  "_version": 0.3,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -64,6 +64,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/dm_h6.nv.json
+++ b/maps/williams/wpc/dm_h6.nv.json
@@ -11,7 +11,7 @@
     "dm_h6"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -68,6 +68,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 952,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 953,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 954,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 955,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/dm_lx4.nv.json
+++ b/maps/williams/wpc/dm_lx4.nv.json
@@ -11,7 +11,7 @@
     "dm_lx4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.3,
+  "_version": 0.4,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -95,13 +95,13 @@
       "start": 1051,
       "encoding": "int"
     },
-    "playing": {
-      "label": "Playing",
-      "start": 134,
+    "attract": {
+      "label": "Attract",
+      "start": 141,
       "encoding": "enum",
       "values": [
-        "ATTRACT",
-        "IN GAME"
+        "IN GAME",
+        "ATTRACT"
       ]
     }
   },

--- a/maps/williams/wpc/dm_lx4.nv.json
+++ b/maps/williams/wpc/dm_lx4.nv.json
@@ -11,7 +11,7 @@
     "dm_lx4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.2,
+  "_version": 0.3,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,26 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1048,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1049,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1050,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs This Ball",
+      "start": 1051,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/dm_lx4.nv.json
+++ b/maps/williams/wpc/dm_lx4.nv.json
@@ -91,9 +91,18 @@
       "encoding": "int"
     },
     "eb_on_this_ball": {
-      "label": "EBs This Ball",
+      "label": "EBs this Ball",
       "start": 1051,
       "encoding": "int"
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 134,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/drac_l1.nv.json
+++ b/maps/williams/wpc/drac_l1.nv.json
@@ -11,7 +11,7 @@
     "drac_l1"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -63,6 +63,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 143,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 943,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 944,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 945,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/dw_l2.nv.json
+++ b/maps/williams/wpc/dw_l2.nv.json
@@ -12,7 +12,7 @@
     "dw_l2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.2,
+  "_version": 0.3,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -273,6 +273,15 @@
       "label": "EBs this Ball",
       "start": 946,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 143,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/dw_l2.nv.json
+++ b/maps/williams/wpc/dw_l2.nv.json
@@ -12,7 +12,7 @@
     "dw_l2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -78,7 +78,6 @@
     },
     "current_player": {
       "label": "Current Player",
-      "short_label": "P#",
       "start": 943,
       "encoding": "int"
     },
@@ -269,6 +268,11 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/fh_905h.nv.json
+++ b/maps/williams/wpc/fh_905h.nv.json
@@ -15,7 +15,7 @@
     "fh_906h"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -67,6 +67,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 10000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1038,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1041,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/fh_l9.nv.json
+++ b/maps/williams/wpc/fh_l9.nv.json
@@ -11,7 +11,7 @@
     "fh_l9"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -68,6 +68,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 10000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1038,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1041,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/fs_lx5.nv.json
+++ b/maps/williams/wpc/fs_lx5.nv.json
@@ -11,7 +11,7 @@
     "fs_lx5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 943,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 944,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 945,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ft_l5.nv.json
+++ b/maps/williams/wpc/ft_l5.nv.json
@@ -11,7 +11,7 @@
     "ft_l5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -75,34 +75,34 @@
       "min": 0,
       "max": 31
     },
-    "playing": {
-      "label": "Playing",
-      "start": 122,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
-      "start": 853,
+      "start": 943,
       "encoding": "int"
     },
     "current_ball": {
       "label": "Ball",
-      "start": 854,
+      "start": 944,
       "encoding": "int"
     },
     "extra_balls": {
       "label": "Extra Balls",
-      "start": 855,
+      "start": 945,
       "encoding": "int"
     },
     "eb_on_this_ball": {
       "label": "EBs this Ball",
-      "start": 856,
+      "start": 946,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 129,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ft_l5.nv.json
+++ b/maps/williams/wpc/ft_l5.nv.json
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 122,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 853,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 854,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 855,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 856,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/gi_l9.nv.json
+++ b/maps/williams/wpc/gi_l9.nv.json
@@ -11,7 +11,7 @@
     "gi_l9"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/gw_l5.nv.json
+++ b/maps/williams/wpc/gw_l5.nv.json
@@ -11,7 +11,7 @@
     "gw_l5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/hd_l3.nv.json
+++ b/maps/williams/wpc/hd_l3.nv.json
@@ -13,7 +13,7 @@
     "che_cho"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -65,6 +65,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 10000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1032,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1033,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1034,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1035,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/hurr_l2.nv.json
+++ b/maps/williams/wpc/hurr_l2.nv.json
@@ -11,7 +11,7 @@
     "hurr_l2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -81,15 +81,6 @@
       "min": 0,
       "max": 31
     },
-    "playing": {
-      "label": "Playing",
-      "start": 134,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 940,
@@ -109,6 +100,15 @@
       "label": "EBs this Ball",
       "start": 943,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 137,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/hurr_l2.nv.json
+++ b/maps/williams/wpc/hurr_l2.nv.json
@@ -80,6 +80,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 134,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 940,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 941,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 942,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 943,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/i500_11r.nv.json
+++ b/maps/williams/wpc/i500_11r.nv.json
@@ -11,7 +11,7 @@
     "i500_11r"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 949,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 950,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 951,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 952,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ij_l7.nv.json
+++ b/maps/williams/wpc/ij_l7.nv.json
@@ -11,7 +11,7 @@
     "ij_l7"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 943,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 944,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 945,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/jb_10r.nv.json
+++ b/maps/williams/wpc/jb_10r.nv.json
@@ -11,7 +11,7 @@
     "jb_10r"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 130,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/jd_l7.nv.json
+++ b/maps/williams/wpc/jd_l7.nv.json
@@ -13,7 +13,7 @@
     "jd_l7"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -76,6 +76,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/jm_12r.nv.json
+++ b/maps/williams/wpc/jm_12r.nv.json
@@ -11,7 +11,7 @@
     "jm_12r"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -69,15 +69,6 @@
       "length": 2,
       "scale": 1000000
     },
-    "playing": {
-      "label": "Playing",
-      "start": 128,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 946,
@@ -97,6 +88,15 @@
       "label": "EBs this Ball",
       "start": 949,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/jm_12r.nv.json
+++ b/maps/williams/wpc/jm_12r.nv.json
@@ -68,6 +68,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 128,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/jy_12.nv.json
+++ b/maps/williams/wpc/jy_12.nv.json
@@ -11,7 +11,7 @@
     "jy_12"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/mb_10.nv.json
+++ b/maps/williams/wpc/mb_10.nv.json
@@ -11,7 +11,7 @@
     "mb_10"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/mb_106.nv.json
+++ b/maps/williams/wpc/mb_106.nv.json
@@ -12,7 +12,7 @@
     "mb_106b"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -75,6 +75,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/mm_10.nv.json
+++ b/maps/williams/wpc/mm_10.nv.json
@@ -13,7 +13,7 @@
     "mm_10"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -70,6 +70,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/mm_109.nv.json
+++ b/maps/williams/wpc/mm_109.nv.json
@@ -13,7 +13,7 @@
     "mm_109c"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -71,15 +71,6 @@
       "length": 2,
       "scale": 1000000
     },
-    "playing": {
-      "label": "Playing",
-      "start": 128,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 946,
@@ -99,6 +90,15 @@
       "label": "EBs this Ball",
       "start": 949,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/mm_109.nv.json
+++ b/maps/williams/wpc/mm_109.nv.json
@@ -70,6 +70,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 128,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/nbaf_31.nv.json
+++ b/maps/williams/wpc/nbaf_31.nv.json
@@ -11,7 +11,7 @@
     "nbaf_31"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -67,6 +67,35 @@
       "start": 7353,
       "encoding": "bcd",
       "length": 2
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 130,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 943,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 944,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 945,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/nf_23x.nv.json
+++ b/maps/williams/wpc/nf_23x.nv.json
@@ -12,7 +12,7 @@
     "nf_23x"
   ],
   "_fileformat": 0.1,
-  "_version": 0.2,
+  "_version": 0.3,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -65,15 +65,6 @@
       "length": 2,
       "scale": 1000000
     },
-    "playing": {
-      "label": "Playing",
-      "start": 122,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 946,
@@ -93,6 +84,15 @@
       "label": "EBs this Ball",
       "start": 949,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 129,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/nf_23x.nv.json
+++ b/maps/williams/wpc/nf_23x.nv.json
@@ -64,6 +64,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 122,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ngg_13.nv.json
+++ b/maps/williams/wpc/ngg_13.nv.json
@@ -11,7 +11,7 @@
     "ngg_13"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -75,15 +75,6 @@
       "min": 0,
       "max": 31
     },
-    "playing": {
-      "label": "Playing",
-      "start": 134,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 952,
@@ -103,6 +94,15 @@
       "label": "EBs this Ball",
       "start": 955,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ngg_13.nv.json
+++ b/maps/williams/wpc/ngg_13.nv.json
@@ -74,6 +74,35 @@
       "encoding": "int",
       "min": 0,
       "max": 31
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 134,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 952,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 953,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 954,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 955,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/pop_lx5.nv.json
+++ b/maps/williams/wpc/pop_lx5.nv.json
@@ -11,7 +11,7 @@
     "pop_lx5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/pz_f4.nv.json
+++ b/maps/williams/wpc/pz_f4.nv.json
@@ -11,7 +11,7 @@
     "pz_f4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -81,6 +81,35 @@
       "start": 7860,
       "encoding": "bcd",
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 148,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1036,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1037,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1038,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1039,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/pz_l3.nv.json
+++ b/maps/williams/wpc/pz_l3.nv.json
@@ -11,7 +11,7 @@
     "pz_l3"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -81,6 +81,35 @@
       "start": 7859,
       "encoding": "bcd",
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 148,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1036,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1037,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1038,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1039,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/rs_l6.nv.json
+++ b/maps/williams/wpc/rs_l6.nv.json
@@ -11,7 +11,7 @@
     "rs_l6"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 947,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 948,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 949,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 950,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/sc_091.nv.json
+++ b/maps/williams/wpc/sc_091.nv.json
@@ -12,7 +12,7 @@
     "sc_091"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -78,6 +78,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 10000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1003,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1004,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1005,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1006,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/sc_18.nv.json
+++ b/maps/williams/wpc/sc_18.nv.json
@@ -14,7 +14,7 @@
     "sc_18s2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -80,6 +80,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 10000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1003,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1004,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1005,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1006,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ss_15.nv.json
+++ b/maps/williams/wpc/ss_15.nv.json
@@ -11,7 +11,7 @@
     "ss_15"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 943,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 944,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 945,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/sttng_l7.nv.json
+++ b/maps/williams/wpc/sttng_l7.nv.json
@@ -11,7 +11,7 @@
     "sttng_l7"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1042,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1043,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1044,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1045,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/t2_l8.nv.json
+++ b/maps/williams/wpc/t2_l8.nv.json
@@ -11,7 +11,7 @@
     "t2_l8"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -75,15 +75,6 @@
       "length": 2,
       "scale": 1000000
     },
-    "playing": {
-      "label": "Playing",
-      "start": 128,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 1039,
@@ -103,6 +94,15 @@
       "label": "EBs this Ball",
       "start": 1042,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/t2_l8.nv.json
+++ b/maps/williams/wpc/t2_l8.nv.json
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 128,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/taf_l5.nv.json
+++ b/maps/williams/wpc/taf_l5.nv.json
@@ -15,7 +15,7 @@
     "taf_h4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -78,6 +78,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/taf_l7.nv.json
+++ b/maps/williams/wpc/taf_l7.nv.json
@@ -11,7 +11,7 @@
     "taf_l7"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/tafg_lx3.nv.json
+++ b/maps/williams/wpc/tafg_lx3.nv.json
@@ -11,7 +11,7 @@
     "tafg_lx3"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/tom_13.nv.json
+++ b/maps/williams/wpc/tom_13.nv.json
@@ -15,7 +15,7 @@
     "tom_14hb"
   ],
   "_fileformat": 0.1,
-  "_version": 0.2,
+  "_version": 0.3,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -56,14 +56,13 @@
     },
     "current_player": {
       "label": "Current Player",
-      "short_label": "P#",
       "start": 943,
       "encoding": "int"
     },
     "current_ball": {
       "label": "Ball",
       "start": 944,
-      "encoding": "bcd"
+      "encoding": "int"
     },
     "credits": {
       "_notes": "1-byte credits followed by 6 bytes encoding partial/bonus credits",
@@ -84,6 +83,16 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 945,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/tom_13.nv.json
+++ b/maps/williams/wpc/tom_13.nv.json
@@ -93,6 +93,15 @@
       "label": "EBs this Ball",
       "start": 946,
       "encoding": "int"
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 134,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/tom_13.nv.json
+++ b/maps/williams/wpc/tom_13.nv.json
@@ -15,7 +15,7 @@
     "tom_14hb"
   ],
   "_fileformat": 0.1,
-  "_version": 0.3,
+  "_version": 0.4,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -94,13 +94,13 @@
       "start": 946,
       "encoding": "int"
     },
-    "playing": {
-      "label": "Playing",
-      "start": 134,
+    "attract": {
+      "label": "Attract",
+      "start": 141,
       "encoding": "enum",
       "values": [
-        "ATTRACT",
-        "IN GAME"
+        "IN GAME",
+        "ATTRACT"
       ]
     }
   },

--- a/maps/williams/wpc/totan_14.nv.json
+++ b/maps/williams/wpc/totan_14.nv.json
@@ -12,7 +12,7 @@
     "totan_14"
   ],
   "_fileformat": 0.1,
-  "_version": 0.2,
+  "_version": 0.3,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -64,6 +64,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 10000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 129,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ts_lx5.nv.json
+++ b/maps/williams/wpc/ts_lx5.nv.json
@@ -12,7 +12,7 @@
     "ts_lx5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.2,
+  "_version": 0.3,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -64,6 +64,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 949,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 950,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 951,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 952,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/tz_92.nv.json
+++ b/maps/williams/wpc/tz_92.nv.json
@@ -11,7 +11,7 @@
     "tz_92"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/tz_94h.nv.json
+++ b/maps/williams/wpc/tz_94h.nv.json
@@ -12,7 +12,7 @@
     "tz_94ch"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -75,6 +75,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/wcs_l2.nv.json
+++ b/maps/williams/wpc/wcs_l2.nv.json
@@ -11,7 +11,7 @@
     "wcs_l2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -74,6 +74,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1042,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1043,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1044,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1045,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/wd_12.nv.json
+++ b/maps/williams/wpc/wd_12.nv.json
@@ -14,7 +14,7 @@
     "wd_12gp"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "last_played": {
     "start": 6144,
     "encoding": "wpc_rtc",
@@ -77,6 +77,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 135,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 946,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 947,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 948,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 949,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ww_l5.nv.json
+++ b/maps/williams/wpc/ww_l5.nv.json
@@ -11,7 +11,7 @@
     "ww_l5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -64,15 +64,6 @@
       "length": 2,
       "scale": 1000000
     },
-    "playing": {
-      "label": "Playing",
-      "start": 134,
-      "encoding": "enum",
-      "values": [
-        "ATTRACT",
-        "IN GAME"
-      ]
-    },
     "current_player": {
       "label": "Current Player",
       "start": 1039,
@@ -92,6 +83,15 @@
       "label": "EBs this Ball",
       "start": 1042,
       "encoding": "int"
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ww_l5.nv.json
+++ b/maps/williams/wpc/ww_l5.nv.json
@@ -63,6 +63,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "playing": {
+      "label": "Playing",
+      "start": 134,
+      "encoding": "enum",
+      "values": [
+        "ATTRACT",
+        "IN GAME"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 1039,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 1040,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 1041,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 1042,
+      "encoding": "int"
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ww_lh6.nv.json
+++ b/maps/williams/wpc/ww_lh6.nv.json
@@ -11,7 +11,7 @@
     "ww_lh6"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "player_count": {
       "label": "Players",
@@ -57,6 +57,35 @@
       "encoding": "bcd",
       "length": 2,
       "scale": 1000000
+    },
+    "attract": {
+      "label": "Attract",
+      "start": 141,
+      "encoding": "enum",
+      "values": [
+        "IN GAME",
+        "ATTRACT"
+      ]
+    },
+    "current_player": {
+      "label": "Current Player",
+      "start": 943,
+      "encoding": "int"
+    },
+    "current_ball": {
+      "label": "Ball",
+      "start": 944,
+      "encoding": "int"
+    },
+    "extra_balls": {
+      "label": "Extra Balls",
+      "start": 945,
+      "encoding": "int"
+    },
+    "eb_on_this_ball": {
+      "label": "EBs this Ball",
+      "start": 946,
+      "encoding": "int"
     }
   },
   "high_scores": [


### PR DESCRIPTION
I manually went through all of the WPC games to find the offset for a 4-byte sequence encoding current player/ball, number of remaining extra balls for the current player, and the total number of extra balls earned on the current ball.

I also identified a byte on the "zero page" (addresses less than 0x100) that seems to reliably report when the game is in attract (or "non-game" mode) versus when a game is underway.  I noticed that byte briefly goes to 0 when entering the test menu, but then quickly returns to 1.