### PR TITLE
Add audits for Williams System 11

### DIFF
--- a/index.json
+++ b/index.json
@@ -56,7 +56,7 @@
   "esha_l4c": "maps/williams/system11/esha_la3.nv.json",
   "esha_la1": "maps/williams/system11/esha_la3.nv.json",
   "esha_la3": "maps/williams/system11/esha_la3.nv.json",
-  "esha_ma3": "maps/williams/system11/esha_la3.nv.json",
+  "esha_ma3": "maps/williams/system11/esha_ma3.nv.json",
   "excaliba": "maps/gottlieb/gottlieb_80b-2.nv.json",
   "excalibr": "maps/gottlieb/gottlieb_80b-2.nv.json",
   "f14_l1": "maps/williams/system11/f14_l1.nv.json",

--- a/maps/williams/system11/bbnny_l2.nv.json
+++ b/maps/williams/system11/bbnny_l2.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Bugs Bunny's Birthday Ball (Bally 1990)",
+    "https://www.ipdb.org/machine.cgi?id=396",
+    "Williams System 11C",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "bbnny_l2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {

--- a/maps/williams/system11/bbnny_l2.nv.json
+++ b/maps/williams/system11/bbnny_l2.nv.json
@@ -121,5 +121,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1630,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1634,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1638,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1642,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1646,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1650,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1654,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1658,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1662,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1666,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1670,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1674,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1678,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1682,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1686,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1690,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1694,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1698,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1702,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1706,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1710,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1714,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1718,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE L. TUNES"
+      },
+      "30": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE LT MILLION"
+      },
+      "31": {
+        "start": 1726,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE 50 MILLION"
+      },
+      "32": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE 500K SKILL"
+      },
+      "33": {
+        "start": 1734,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE 500K CAPB"
+      },
+      "34": {
+        "start": 1738,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE CAP. BALL"
+      },
+      "35": {
+        "start": 1742,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "NOT USED"
+      },
+      "36": {
+        "start": 1746,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TWEETY BONUS"
+      },
+      "37": {
+        "start": 1750,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE SHOP SPREE"
+      },
+      "38": {
+        "start": 1754,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE S.P. EXBALL"
+      },
+      "39": {
+        "start": 1834,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1758,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1762,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1770,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1774,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1778,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1782,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1786,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1790,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1794,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/bbnny_l2.nv.json
+++ b/maps/williams/system11/bbnny_l2.nv.json
@@ -120,6 +120,12 @@
       "end": 1801,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1519,
+      "end": 1527,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -387,6 +393,18 @@
         "encoding": "bcd",
         "length": 3,
         "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1519,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1523,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
       }
     }
   }

--- a/maps/williams/system11/bcats_l5.nv.json
+++ b/maps/williams/system11/bcats_l5.nv.json
@@ -3,7 +3,8 @@
     "Compiled by Francis De Brabandere.",
     "Bad Cats (Williams 1989)",
     "https://www.ipdb.org/machine.cgi?id=127",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "bcats_l5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/bcats_l5.nv.json
+++ b/maps/williams/system11/bcats_l5.nv.json
@@ -122,6 +122,12 @@
       "end": 1802,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1488,
+      "end": 1516,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -389,6 +395,48 @@
         "encoding": "bcd",
         "length": 3,
         "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1488,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FISH COL."
+      },
+      "53": {
+        "start": 1492,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FISH COL. 10X"
+      },
+      "54": {
+        "start": 1496,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FISH 5 MILLION"
+      },
+      "55": {
+        "start": 1500,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS MULTIPLIER"
+      },
+      "56": {
+        "start": 1504,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "57": {
+        "start": 1508,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
+      },
+      "58": {
+        "start": 1512,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONSOL. XTRA BALL"
       }
     }
   }

--- a/maps/williams/system11/bcats_l5.nv.json
+++ b/maps/williams/system11/bcats_l5.nv.json
@@ -123,5 +123,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1631,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1635,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1639,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1643,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1647,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1651,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1655,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1659,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1663,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1667,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1671,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1675,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1679,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1683,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1687,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1691,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1695,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1699,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1703,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1707,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1711,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1715,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1719,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "UNLM. MIL. LIT"
+      },
+      "30": {
+        "start": 1723,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "UNLM. MIL. AWARDED"
+      },
+      "31": {
+        "start": 1727,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "20 MILLION LIT"
+      },
+      "32": {
+        "start": 1731,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "20 MIL. AWARDED"
+      },
+      "33": {
+        "start": 1735,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TIGER RAMP COMPL."
+      },
+      "34": {
+        "start": 1739,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TIGER RMP. MISSED"
+      },
+      "35": {
+        "start": 1743,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "GOLDFISH RAMP"
+      },
+      "36": {
+        "start": 1747,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOTS AWARDED"
+      },
+      "37": {
+        "start": 1751,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL WHL. SPINS"
+      },
+      "38": {
+        "start": 1755,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CURIOSITY SPINS"
+      },
+      "39": {
+        "start": 1835,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1759,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1763,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1767,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1771,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1775,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1779,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1783,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1787,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1791,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1795,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1799,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/bguns_l8.nv.json
+++ b/maps/williams/system11/bguns_l8.nv.json
@@ -4,7 +4,8 @@
     "Big Guns (Williams 1987)",
     "https://www.ipdb.org/machine.cgi?id=250",
     "Williams System 11B",
-    "This seems to have the same layout as Space Station (Williams 1987)"
+    "This seems to have the same layout as Space Station (Williams 1987)",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -14,7 +15,7 @@
     "bguns_l8"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/bguns_l8.nv.json
+++ b/maps/williams/system11/bguns_l8.nv.json
@@ -329,13 +329,13 @@
         "start": 1812,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.0-O.4 M. SCORE"
+        "label": "0.0-0.4 M. SCORE"
       },
       "41": {
         "start": 1816,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 M. SCORE"
+        "label": "0.5-0.9 M. SCORE"
       },
       "42": {
         "start": 1820,

--- a/maps/williams/system11/bguns_l8.nv.json
+++ b/maps/williams/system11/bguns_l8.nv.json
@@ -124,5 +124,237 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "QUEEN RESCUED"
+      },
+      "30": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "INVIN. TOTAL"
+      },
+      "31": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ADV. 'X' TOTAL"
+      },
+      "32": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TROLLS AWARDED"
+      },
+      "33": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RET.LANE EX. BALL"
+      },
+      "34": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "E. O. G. EX. BALL"
+      },
+      "35": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "E. O. G. KICKS"
+      },
+      "36": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "GUARDS SPECIAL"
+      },
+      "37": {
+        "start": 1804,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI- BALLS"
+      },
+      "38": {
+        "start": 1808,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOWERS AWARDED"
+      },
+      "39": {
+        "start": 1863,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1812,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 M. SCORE"
+      },
+      "41": {
+        "start": 1816,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 M. SCORE"
+      },
+      "42": {
+        "start": 1820,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 M. SCORE"
+      },
+      "43": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 M. SCORE"
+      },
+      "44": {
+        "start": 1828,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.4 M. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/bguns_la.nv.json
+++ b/maps/williams/system11/bguns_la.nv.json
@@ -115,10 +115,243 @@
   ],
   "checksum8": [
     {
+      "_notes": "extra, unused audit 1800-1803",
       "start": 1648,
-      "end": 1803,
+      "end": 1799,
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "QUEEN RESCUED"
+      },
+      "30": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "INVIN. TOTAL"
+      },
+      "31": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ADV. 'X' TOTAL"
+      },
+      "32": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TROLLS AWARDED"
+      },
+      "33": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RET.LANE EX. BALL"
+      },
+      "34": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "E. O. G. EX. BALL"
+      },
+      "35": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "E. O. G. KICKS"
+      },
+      "36": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "GUARDS SPECIAL"
+      },
+      "37": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI- BALLS"
+      },
+      "38": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOWERS AWARDED"
+      },
+      "39": {
+        "start": 1835,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 M. SCORE"
+      },
+      "41": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 M. SCORE"
+      },
+      "42": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 M. SCORE"
+      },
+      "43": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 M. SCORE"
+      },
+      "44": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.4 M. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/bguns_la.nv.json
+++ b/maps/williams/system11/bguns_la.nv.json
@@ -1,6 +1,10 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Big Guns (Williams 1987)",
+    "https://www.ipdb.org/machine.cgi?id=250",
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +14,7 @@
     "bguns_la"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/bk2k_l4.nv.json
+++ b/maps/williams/system11/bk2k_l4.nv.json
@@ -192,134 +192,128 @@
         "length": 3,
         "label": "EXTRA BALLS"
       },
-      "17": {
-        "start": 1648,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "AVG. BALL TIME"
-      },
       "18": {
-        "start": 1652,
+        "start": 1648,
         "encoding": "bcd",
         "length": 3,
         "label": "MINUTES OF PLAY"
       },
       "19": {
-        "start": 1656,
+        "start": 1652,
         "encoding": "bcd",
         "length": 3,
         "label": "BALLS PLAYED"
       },
       "20": {
-        "start": 1660,
+        "start": 1656,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY1 AWARDS"
       },
       "21": {
-        "start": 1664,
+        "start": 1660,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY2 AWARDS"
       },
       "22": {
-        "start": 1668,
+        "start": 1664,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY3 AWARDS"
       },
       "23": {
-        "start": 1672,
+        "start": 1668,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY4 AWARDS"
       },
       "24": {
-        "start": 1676,
+        "start": 1672,
         "encoding": "bcd",
         "length": 3,
         "label": "1 PLAYER GAMES"
       },
       "25": {
-        "start": 1680,
+        "start": 1676,
         "encoding": "bcd",
         "length": 3,
         "label": "2 PLAYER GAMES"
       },
       "26": {
-        "start": 1684,
+        "start": 1680,
         "encoding": "bcd",
         "length": 3,
         "label": "3 PLAYER GAMES"
       },
       "27": {
-        "start": 1688,
+        "start": 1684,
         "encoding": "bcd",
         "length": 3,
         "label": "4 PLAYER GAMES"
       },
       "28": {
-        "start": 1692,
+        "start": 1688,
         "encoding": "bcd",
         "length": 3,
         "label": "BURN-IN CYCLES"
       },
       "29": {
-        "start": 1696,
+        "start": 1692,
         "encoding": "bcd",
         "length": 3,
         "label": "SPELL WAR"
       },
       "30": {
-        "start": 1700,
+        "start": 1696,
         "encoding": "bcd",
         "length": 3,
         "label": "SPELL KNIGHT"
       },
       "31": {
-        "start": 1704,
+        "start": 1700,
         "encoding": "bcd",
         "length": 3,
         "label": "UPPER RAMP SHOTS"
       },
       "32": {
-        "start": 1708,
+        "start": 1704,
         "encoding": "bcd",
         "length": 3,
         "label": "EXTRA BALL LIT"
       },
       "33": {
-        "start": 1712,
+        "start": 1708,
         "encoding": "bcd",
         "length": 3,
         "label": "RAMP EXTRA BALLS"
       },
       "34": {
-        "start": 1716,
+        "start": 1712,
         "encoding": "bcd",
         "length": 3,
         "label": "2 BALL MULTIBALL"
       },
       "35": {
-        "start": 1720,
+        "start": 1716,
         "encoding": "bcd",
         "length": 3,
         "label": "MILLION VIA WAR"
       },
       "36": {
-        "start": 1724,
+        "start": 1720,
         "encoding": "bcd",
         "length": 3,
         "label": "3 BALL MULTIBALL"
       },
       "37": {
-        "start": 1728,
+        "start": 1724,
         "encoding": "bcd",
         "length": 3,
         "label": "JACKPOTS AWARDED"
       },
       "38": {
-        "start": 1732,
+        "start": 1728,
         "encoding": "bcd",
         "length": 3,
         "label": "RANSOMS AWARDED"
@@ -334,13 +328,13 @@
         "start": 1736,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.0-O.4 MIL. SCORE"
+        "label": "0.0-0.4 MIL. SCORE"
       },
       "41": {
         "start": 1740,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 MIL. SCORE"
+        "label": "0.5-0.9 MIL. SCORE"
       },
       "42": {
         "start": 1744,
@@ -378,29 +372,29 @@
         "length": 3,
         "label": "8.0-99.9 MIL. SCORE"
       },
-      "48": {
-        "start": 1768,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "FIRST REPLAY IS"
-      },
-      "49": {
-        "start": 1772,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "AVG. GAME 200 MIN."
-      },
       "50": {
-        "start": 1776,
+        "start": 1768,
         "encoding": "bcd",
         "length": 3,
         "label": "WHEEL SPINS"
       },
       "51": {
-        "start": 1780,
+        "start": 1772,
         "encoding": "bcd",
         "length": 3,
         "label": "LEFT DRAINS"
+      },
+      "52": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "KICKBACKS"
+      },
+      "53": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
       }
     }
   }

--- a/maps/williams/system11/bk2k_l4.nv.json
+++ b/maps/williams/system11/bk2k_l4.nv.json
@@ -3,7 +3,8 @@
     "Compiled by Francis De Brabandere.",
     "Black Knight (Williams 1989)",
     "https://www.ipdb.org/machine.cgi?id=311",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "bk2k_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/bk2k_l4.nv.json
+++ b/maps/williams/system11/bk2k_l4.nv.json
@@ -123,5 +123,285 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1604,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1608,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1612,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1616,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1620,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1624,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1628,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1632,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1636,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1640,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1644,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "17": {
+        "start": 1648,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVG. BALL TIME"
+      },
+      "18": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPELL WAR"
+      },
+      "30": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPELL KNIGHT"
+      },
+      "31": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "UPPER RAMP SHOTS"
+      },
+      "32": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALL LIT"
+      },
+      "33": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RAMP EXTRA BALLS"
+      },
+      "34": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 BALL MULTIBALL"
+      },
+      "35": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MILLION VIA WAR"
+      },
+      "36": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 BALL MULTIBALL"
+      },
+      "37": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOTS AWARDED"
+      },
+      "38": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RANSOMS AWARDED"
+      },
+      "39": {
+        "start": 1815,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S. RESET COUNTER"
+      },
+      "40": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.9 MIL. SCORE"
+      },
+      "43": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-5.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-99.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FIRST REPLAY IS"
+      },
+      "49": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVG. GAME 200 MIN."
+      },
+      "50": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "WHEEL SPINS"
+      },
+      "51": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/bnzai_l3.nv.json
+++ b/maps/williams/system11/bnzai_l3.nv.json
@@ -123,5 +123,249 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1636,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1640,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1644,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1648,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ALL CHLNGED"
+      },
+      "30": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ALL BEATEN"
+      },
+      "31": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI BALLS"
+      },
+      "32": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "KING OF HILL"
+      },
+      "33": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "VICTORY LAP"
+      },
+      "34": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "INSTANT REMATCH"
+      },
+      "35": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL LIFTS"
+      },
+      "36": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FINISH LINE"
+      },
+      "37": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SKILL SHOTS"
+      },
+      "38": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CLIFF JUMPS"
+      },
+      "39": {
+        "start": 1823,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 M. SCORE"
+      },
+      "41": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 M. SCORE"
+      },
+      "42": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 M. SCORE"
+      },
+      "43": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 M. SCORE"
+      },
+      "44": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.4 M. SCORE"
+      },
+      "45": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.5-9.9 M. SCORE"
+      },
+      "46": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PLAY AT TI"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/bnzai_l3.nv.json
+++ b/maps/williams/system11/bnzai_l3.nv.json
@@ -325,46 +325,40 @@
         "label": "H.S.RESET COUNTER"
       },
       "40": {
-        "start": 1764,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "O.0-O.4 M. SCORE"
-      },
-      "41": {
         "start": 1768,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 M. SCORE"
+        "label": "0.0-0.4 M. SCORE"
+      },
+      "41": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 M. SCORE"
       },
       "42": {
-        "start": 1772,
+        "start": 1776,
         "encoding": "bcd",
         "length": 3,
         "label": "1.0-1.4 M. SCORE"
       },
       "43": {
-        "start": 1776,
+        "start": 1780,
         "encoding": "bcd",
         "length": 3,
         "label": "1.5-1.9 M. SCORE"
       },
       "44": {
-        "start": 1780,
+        "start": 1784,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.4 M. SCORE"
       },
       "45": {
-        "start": 1784,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "2.5-9.9 M. SCORE"
-      },
-      "46": {
         "start": 1788,
         "encoding": "bcd",
         "length": 3,
-        "label": "PLAY AT TI"
+        "label": "2.5-9.9 M. SCORE"
       }
     }
   }

--- a/maps/williams/system11/bnzai_l3.nv.json
+++ b/maps/williams/system11/bnzai_l3.nv.json
@@ -3,7 +3,8 @@
     "Compiled by Francis De Brabandere.",
     "Banzai Run (Williams 1988)",
     "https://www.ipdb.org/machine.cgi?id=175",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "bnzai_l3"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/cycln_l5.nv.json
+++ b/maps/williams/system11/cycln_l5.nv.json
@@ -123,5 +123,243 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT AWARDS"
+      },
+      "30": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 MILL. AWARDS"
+      },
+      "31": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FERRIS AWARDS"
+      },
+      "32": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SHUTTLE 100K'S"
+      },
+      "33": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "M. WHEEL SPINS"
+      },
+      "34": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CYCLONE SHOTS"
+      },
+      "35": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "COMET SHOTS"
+      },
+      "36": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "OUTLANE EX. BALL"
+      },
+      "37": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "X SPECIAL"
+      },
+      "38": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "L/R DRAINS"
+      },
+      "39": {
+        "start": 1835,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 M. SCORE"
+      },
+      "41": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 M. SCORE"
+      },
+      "42": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 M. SCORE"
+      },
+      "43": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 M. SCORE"
+      },
+      "44": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.4 M. SCORE"
+      },
+      "45": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.5-9.9 M. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/cycln_l5.nv.json
+++ b/maps/williams/system11/cycln_l5.nv.json
@@ -3,7 +3,8 @@
     "Compiled by Francis De Brabandere.",
     "Cyclone (Williams 1988)",
     "https://www.ipdb.org/machine.cgi?id=617",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "cycln_l5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/cycln_l5.nv.json
+++ b/maps/williams/system11/cycln_l5.nv.json
@@ -328,13 +328,13 @@
         "start": 1780,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.0-O.4 M. SCORE"
+        "label": "0.0-0.4 M. SCORE"
       },
       "41": {
         "start": 1784,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 M. SCORE"
+        "label": "0.5-0.9 M. SCORE"
       },
       "42": {
         "start": 1788,

--- a/maps/williams/system11/dd_l2.nv.json
+++ b/maps/williams/system11/dd_l2.nv.json
@@ -134,6 +134,12 @@
       "end": 1801,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1512,
+      "end": 1523,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -310,7 +316,7 @@
         "start": 1742,
         "encoding": "bcd",
         "length": 3,
-        "label": "MIXER?S ON LINE"
+        "label": "MIXER'S ON LINE"
       },
       "36": {
         "start": 1746,
@@ -401,6 +407,24 @@
         "encoding": "bcd",
         "length": 3,
         "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1512,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1516,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
+      },
+      "54": {
+        "start": 1520,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES ON"
       }
     }
   }

--- a/maps/williams/system11/dd_l2.nv.json
+++ b/maps/williams/system11/dd_l2.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Dr. Dude and His Excellent Ray (Bally 1990)",
+    "https://www.ipdb.org/machine.cgi?id=737",
+    "Williams System 11C",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "dd_l2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {

--- a/maps/williams/system11/dd_l2.nv.json
+++ b/maps/williams/system11/dd_l2.nv.json
@@ -135,5 +135,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1630,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1634,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1638,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1642,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1646,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1650,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1654,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1658,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1662,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1666,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1670,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1674,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1678,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1682,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1686,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1690,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1694,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1698,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1702,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1706,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1710,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1714,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1718,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MILLION AWARDS"
+      },
+      "30": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT AWARDS"
+      },
+      "31": {
+        "start": 1726,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "GAZILLION HITS"
+      },
+      "32": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SUPER DUDES"
+      },
+      "33": {
+        "start": 1734,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTIBALLS"
+      },
+      "34": {
+        "start": 1738,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "X. RAY ACTIVATED"
+      },
+      "35": {
+        "start": 1742,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIXER?S ON LINE"
+      },
+      "36": {
+        "start": 1746,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "R. DROP LITE EX.B."
+      },
+      "37": {
+        "start": 1750,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "R. DROP EX. BALLS"
+      },
+      "38": {
+        "start": 1754,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONSOL. EX. BALLS"
+      },
+      "39": {
+        "start": 1834,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1758,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1762,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1770,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1774,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1778,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1782,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1786,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1790,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1794,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/diner_l4.nv.json
+++ b/maps/williams/system11/diner_l4.nv.json
@@ -124,6 +124,12 @@
       "end": 1801,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1512,
+      "end": 1523,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -194,134 +200,128 @@
         "length": 3,
         "label": "EXTRA BALLS"
       },
-      "17": {
-        "start": 1674,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "AVG. BALL TIME"
-      },
       "18": {
-        "start": 1678,
+        "start": 1674,
         "encoding": "bcd",
         "length": 3,
         "label": "MINUTES OF PLAY"
       },
       "19": {
-        "start": 1682,
+        "start": 1678,
         "encoding": "bcd",
         "length": 3,
         "label": "BALLS PLAYED"
       },
       "20": {
-        "start": 1686,
+        "start": 1682,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY1 AWARDS"
       },
       "21": {
-        "start": 1690,
+        "start": 1686,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY2 AWARDS"
       },
       "22": {
-        "start": 1694,
+        "start": 1690,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY3 AWARDS"
       },
       "23": {
-        "start": 1698,
+        "start": 1694,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY4 AWARDS"
       },
       "24": {
-        "start": 1702,
+        "start": 1698,
         "encoding": "bcd",
         "length": 3,
         "label": "1 PLAYER GAMES"
       },
       "25": {
-        "start": 1706,
+        "start": 1702,
         "encoding": "bcd",
         "length": 3,
         "label": "2 PLAYER GAMES"
       },
       "26": {
-        "start": 1710,
+        "start": 1706,
         "encoding": "bcd",
         "length": 3,
         "label": "3 PLAYER GAMES"
       },
       "27": {
-        "start": 1714,
+        "start": 1710,
         "encoding": "bcd",
         "length": 3,
         "label": "4 PLAYER GAMES"
       },
       "28": {
-        "start": 1718,
+        "start": 1714,
         "encoding": "bcd",
         "length": 3,
         "label": "BURN-IN CYCLES"
       },
       "29": {
-        "start": 1722,
+        "start": 1718,
         "encoding": "bcd",
         "length": 3,
         "label": "MULTI-BALLS"
       },
       "30": {
-        "start": 1726,
+        "start": 1722,
         "encoding": "bcd",
         "length": 3,
         "label": "RUSH AWARDS"
       },
       "31": {
-        "start": 1730,
+        "start": 1726,
         "encoding": "bcd",
         "length": 3,
         "label": "DINE-TIME AWARDS"
       },
       "32": {
-        "start": 1734,
+        "start": 1730,
         "encoding": "bcd",
         "length": 3,
         "label": "1,500,000 GRILL"
       },
       "33": {
-        "start": 1738,
+        "start": 1734,
         "encoding": "bcd",
         "length": 3,
         "label": "CUP AWARDS"
       },
       "34": {
-        "start": 1742,
+        "start": 1738,
         "encoding": "bcd",
         "length": 3,
         "label": "EAT COMPLETE"
       },
       "35": {
-        "start": 1746,
+        "start": 1742,
         "encoding": "bcd",
         "length": 3,
         "label": "NOT USED"
       },
       "36": {
-        "start": 1750,
+        "start": 1746,
         "encoding": "bcd",
         "length": 3,
         "label": "NOT USED"
       },
       "37": {
-        "start": 1754,
+        "start": 1750,
         "encoding": "bcd",
         "length": 3,
         "label": "CONSOL. EX. BALLS"
       },
       "38": {
-        "start": 1758,
+        "start": 1754,
         "encoding": "bcd",
         "length": 3,
         "label": "EARNED EX. BALLS"
@@ -333,64 +333,88 @@
         "label": "H.S. RESET COUNTER"
       },
       "40": {
-        "start": 1762,
+        "start": 1758,
         "encoding": "bcd",
         "length": 3,
         "label": "0.0-0.4 MIL. SCORE"
       },
       "41": {
-        "start": 1766,
+        "start": 1762,
         "encoding": "bcd",
         "length": 3,
         "label": "0.5-0.9 MIL. SCORE"
       },
       "42": {
-        "start": 1770,
+        "start": 1766,
         "encoding": "bcd",
         "length": 3,
         "label": "1.0-1.4 MIL. SCORE"
       },
       "43": {
-        "start": 1774,
+        "start": 1770,
         "encoding": "bcd",
         "length": 3,
         "label": "1.5-1.9 MIL. SCORE"
       },
       "44": {
-        "start": 1778,
+        "start": 1774,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.9 MIL. SCORE"
       },
       "45": {
-        "start": 1782,
+        "start": 1778,
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-3.9 MIL. SCORE"
       },
       "46": {
-        "start": 1786,
+        "start": 1782,
         "encoding": "bcd",
         "length": 3,
         "label": "4.0-4.9 MIL. SCORE"
       },
       "47": {
-        "start": 1790,
+        "start": 1786,
         "encoding": "bcd",
         "length": 3,
         "label": "5.0-5.9 MIL. SCORE"
       },
       "48": {
-        "start": 1794,
+        "start": 1790,
         "encoding": "bcd",
         "length": 3,
         "label": "6.0-7.9 MIL. SCORE"
       },
       "49": {
-        "start": 1798,
+        "start": 1794,
         "encoding": "bcd",
         "length": 3,
         "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1512,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1516,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
+      },
+      "54": {
+        "start": 1520,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES ON"
       }
     }
   }

--- a/maps/williams/system11/diner_l4.nv.json
+++ b/maps/williams/system11/diner_l4.nv.json
@@ -125,5 +125,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1630,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1634,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1638,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1642,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1646,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1650,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1654,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1658,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1662,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1666,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1670,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "17": {
+        "start": 1674,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVG. BALL TIME"
+      },
+      "18": {
+        "start": 1678,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1682,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1686,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1690,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1694,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1698,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1702,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1706,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1710,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1714,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1718,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI-BALLS"
+      },
+      "30": {
+        "start": 1726,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RUSH AWARDS"
+      },
+      "31": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DINE-TIME AWARDS"
+      },
+      "32": {
+        "start": 1734,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1,500,000 GRILL"
+      },
+      "33": {
+        "start": 1738,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CUP AWARDS"
+      },
+      "34": {
+        "start": 1742,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EAT COMPLETE"
+      },
+      "35": {
+        "start": 1746,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "NOT USED"
+      },
+      "36": {
+        "start": 1750,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "NOT USED"
+      },
+      "37": {
+        "start": 1754,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONSOL. EX. BALLS"
+      },
+      "38": {
+        "start": 1758,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EARNED EX. BALLS"
+      },
+      "39": {
+        "start": 1834,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S. RESET COUNTER"
+      },
+      "40": {
+        "start": 1762,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1770,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1774,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1778,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1782,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1786,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1790,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1794,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/diner_l4.nv.json
+++ b/maps/williams/system11/diner_l4.nv.json
@@ -1,6 +1,10 @@
 {
   "_notes": [
-    "Compiled by HorsePin"
+    "Compiled by HorsePin",
+    "Diner (Williams 1990)",
+    "https://www.ipdb.org/machine.cgi?id=681",
+    "Williams System 11C",
+    "2025-03 v0.3: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2022 https://github.com/horseyhorsey",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +14,7 @@
     "diner_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.2,
+  "_version": 0.3,
   "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {

--- a/maps/williams/system11/eatpm_l4.nv.json
+++ b/maps/williams/system11/eatpm_l4.nv.json
@@ -119,5 +119,285 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1604,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1608,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1612,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1616,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1620,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1624,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1628,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1632,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1636,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1640,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1644,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1648,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 1 AWARDS"
+      },
+      "21": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 2 AWARDS"
+      },
+      "22": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 3 AWARDS"
+      },
+      "23": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 4 AWARDS"
+      },
+      "24": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT OUTLANES"
+      },
+      "30": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT OUTLANES"
+      },
+      "31": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT RAMPS"
+      },
+      "32": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT RAMPS"
+      },
+      "33": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ELVIRA SPELLED"
+      },
+      "34": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ELVIRA AWARDS"
+      },
+      "35": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULITBALLS"
+      },
+      "36": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOTS"
+      },
+      "37": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RAMP MILLIONS"
+      },
+      "38": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EJECT MILLIONS"
+      },
+      "39": {
+        "start": 1815,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S. RESET COUNTER"
+      },
+      "40": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.9 MIL. SCORE"
+      },
+      "43": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-5.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-99.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FIRST REPLAY IS"
+      },
+      "49": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVG. GAME 200 MIN."
+      },
+      "50": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PIZZA COMPLETE"
+      },
+      "51": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JAM COMPLETE"
+      },
+      "52": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FLIP UP COMPLETE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/eatpm_l4.nv.json
+++ b/maps/williams/system11/eatpm_l4.nv.json
@@ -321,82 +321,76 @@
         "label": "H.S. RESET COUNTER"
       },
       "40": {
-        "start": 1732,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "O.0-O.4 MIL. SCORE"
-      },
-      "41": {
         "start": 1736,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 MIL. SCORE"
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
       },
       "42": {
-        "start": 1740,
+        "start": 1744,
         "encoding": "bcd",
         "length": 3,
         "label": "1.0-1.9 MIL. SCORE"
       },
       "43": {
-        "start": 1744,
+        "start": 1748,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.9 MIL. SCORE"
       },
       "44": {
-        "start": 1748,
+        "start": 1752,
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-3.9 MIL. SCORE"
       },
       "45": {
-        "start": 1752,
+        "start": 1756,
         "encoding": "bcd",
         "length": 3,
         "label": "4.0-5.9 MIL. SCORE"
       },
       "46": {
-        "start": 1756,
+        "start": 1760,
         "encoding": "bcd",
         "length": 3,
         "label": "6.0-7.9 MIL. SCORE"
       },
       "47": {
-        "start": 1760,
+        "start": 1764,
         "encoding": "bcd",
         "length": 3,
         "label": "8.0-99.9 MIL. SCORE"
       },
-      "48": {
-        "start": 1764,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "FIRST REPLAY IS"
-      },
-      "49": {
-        "start": 1768,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "AVG. GAME 200 MIN."
-      },
       "50": {
-        "start": 1772,
+        "start": 1768,
         "encoding": "bcd",
         "length": 3,
         "label": "PIZZA COMPLETE"
       },
       "51": {
-        "start": 1776,
+        "start": 1772,
         "encoding": "bcd",
         "length": 3,
         "label": "JAM COMPLETE"
       },
       "52": {
-        "start": 1780,
+        "start": 1776,
         "encoding": "bcd",
         "length": 3,
         "label": "FLIP UP COMPLETE"
+      },
+      "53": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DEAD HEADS COMP."
       }
     }
   }

--- a/maps/williams/system11/eatpm_l4.nv.json
+++ b/maps/williams/system11/eatpm_l4.nv.json
@@ -1,5 +1,11 @@
 {
-  "_notes": "Compiled by Mike Metzger.",
+  "_notes": [
+    "Compiled by Mike Metzger.",
+    "Elvira and the Party Monsters (Bally 1989)",
+    "https://www.ipdb.org/machine.cgi?id=782",
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
+  ],
   "_copyright": "Copyright (C) 2017 by Mike Metzger <mike@flexiblecreations.com>",
   "_license": "GNU Lesser General Public License v3.0",
   "_endian": "big",
@@ -9,7 +15,7 @@
     "eatpm_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/esha_la3.nv.json
+++ b/maps/williams/system11/esha_la3.nv.json
@@ -1,9 +1,10 @@
 {
   "_notes": [
     "Compiled by Francis De Brabandere.",
-    "Earth Shaker (Williams 1989)",
+    "Earthshaker (Williams 1989)",
     "https://www.ipdb.org/machine.cgi?id=753",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -15,7 +16,7 @@
     "esha_l4c"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/esha_la3.nv.json
+++ b/maps/williams/system11/esha_la3.nv.json
@@ -12,8 +12,7 @@
   "_roms": [
     "esha_la1",
     "esha_la3",
-    "esha_l4c",
-    "esha_ma3"
+    "esha_l4c"
   ],
   "_fileformat": 0.1,
   "_version": 0.1,
@@ -277,7 +276,7 @@
         "start": 1700,
         "encoding": "bcd",
         "length": 3,
-        "label": "FACE THE THING"
+        "label": "HEAD FOR SHELTER"
       },
       "32": {
         "start": 1704,
@@ -301,13 +300,13 @@
         "start": 1716,
         "encoding": "bcd",
         "length": 3,
-        "label": "FIRE FIGHTS"
+        "label": "TRIPS TO FAULT"
       },
       "36": {
         "start": 1720,
         "encoding": "bcd",
         "length": 3,
-        "label": "LIGHTNING RIDES"
+        "label": "MILES TRAVELED"
       },
       "37": {
         "start": 1724,
@@ -328,82 +327,76 @@
         "label": "H.S. RESET COUNTER"
       },
       "40": {
-        "start": 1732,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "O.0-O.4 MIL. SCORE"
-      },
-      "41": {
         "start": 1736,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 MIL. SCORE"
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
       },
       "42": {
-        "start": 1740,
+        "start": 1744,
         "encoding": "bcd",
         "length": 3,
         "label": "1.0-1.9 MIL. SCORE"
       },
       "43": {
-        "start": 1744,
+        "start": 1748,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.9 MIL. SCORE"
       },
       "44": {
-        "start": 1748,
+        "start": 1752,
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-3.9 MIL. SCORE"
       },
       "45": {
-        "start": 1752,
+        "start": 1756,
         "encoding": "bcd",
         "length": 3,
         "label": "4.0-5.9 MIL. SCORE"
       },
       "46": {
-        "start": 1756,
+        "start": 1760,
         "encoding": "bcd",
         "length": 3,
         "label": "6.0-7.9 MIL. SCORE"
       },
       "47": {
-        "start": 1760,
+        "start": 1764,
         "encoding": "bcd",
         "length": 3,
         "label": "8.0-99.9 MIL. SCORE"
       },
-      "48": {
-        "start": 1764,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "FIRST REPLAY IS"
-      },
-      "49": {
-        "start": 1768,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "AVG. GAME 200 MIN."
-      },
       "50": {
-        "start": 1772,
+        "start": 1768,
         "encoding": "bcd",
         "length": 3,
         "label": "BONUS 2X REACHED"
       },
       "51": {
-        "start": 1776,
+        "start": 1772,
         "encoding": "bcd",
         "length": 3,
         "label": "BONUS 3X REACHED"
       },
       "52": {
-        "start": 1780,
+        "start": 1776,
         "encoding": "bcd",
         "length": 3,
         "label": "BONUS 4X REACHED"
+      },
+      "53": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS 5X REACHED"
       }
     }
   }

--- a/maps/williams/system11/esha_la3.nv.json
+++ b/maps/williams/system11/esha_la3.nv.json
@@ -126,5 +126,285 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1604,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1608,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1612,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1616,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1620,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1624,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1628,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1632,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1636,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1640,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1644,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1648,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 1 AWARDS"
+      },
+      "21": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 2 AWARDS"
+      },
+      "22": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 3 AWARDS"
+      },
+      "23": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 4 AWARDS"
+      },
+      "24": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT OUTLANE"
+      },
+      "30": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT OUTLANE"
+      },
+      "31": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FACE THE THING"
+      },
+      "32": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOTS"
+      },
+      "33": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 BL. MULTI-BALLS"
+      },
+      "34": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "100K CENTER RAMP"
+      },
+      "35": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FIRE FIGHTS"
+      },
+      "36": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LIGHTNING RIDES"
+      },
+      "37": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 BL. MULTI-BALLS"
+      },
+      "38": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MILLION SHOTS"
+      },
+      "39": {
+        "start": 1815,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S. RESET COUNTER"
+      },
+      "40": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.9 MIL. SCORE"
+      },
+      "43": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-5.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-99.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FIRST REPLAY IS"
+      },
+      "49": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVG. GAME 200 MIN."
+      },
+      "50": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS 2X REACHED"
+      },
+      "51": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS 3X REACHED"
+      },
+      "52": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS 4X REACHED"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/esha_ma3.nv.json
+++ b/maps/williams/system11/esha_ma3.nv.json
@@ -1,9 +1,10 @@
 {
   "_notes": [
     "Compiled by Francis De Brabandere.",
-    "Metallica (re-themed Williams Earth Shaker)",
+    "Metallica (re-themed Williams Earthshaker)",
     "https://www.ipdb.org/machine.cgi?id=5478",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "esha_ma3"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/esha_ma3.nv.json
+++ b/maps/williams/system11/esha_ma3.nv.json
@@ -1,21 +1,23 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Francis De Brabandere.",
+    "Metallica (re-themed Williams Earth Shaker)",
+    "https://www.ipdb.org/machine.cgi?id=5478",
+    "Williams System 11B"
   ],
-  "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
+  "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
   "_endian": "big",
   "_ramsize": 2048,
   "_roms": [
-    "rvrbt_l3"
+    "esha_ma3"
   ],
   "_fileformat": 0.1,
   "_version": 0.1,
-  "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {
       "label": "Credits",
-      "start": 1805,
+      "start": 1786,
       "length": 1,
       "encoding": "bcd"
     },
@@ -61,12 +63,12 @@
       "label": "First Place",
       "short_label": "1st",
       "initials": {
-        "start": 1822,
+        "start": 1803,
         "encoding": "ch",
         "length": 3
       },
       "score": {
-        "start": 1806,
+        "start": 1787,
         "encoding": "bcd",
         "length": 4
       }
@@ -75,12 +77,12 @@
       "label": "Second Place",
       "short_label": "2nd",
       "initials": {
-        "start": 1825,
+        "start": 1806,
         "encoding": "ch",
         "length": 3
       },
       "score": {
-        "start": 1810,
+        "start": 1791,
         "encoding": "bcd",
         "length": 4
       }
@@ -89,12 +91,12 @@
       "label": "Third Place",
       "short_label": "3rd",
       "initials": {
-        "start": 1828,
+        "start": 1809,
         "encoding": "ch",
         "length": 3
       },
       "score": {
-        "start": 1814,
+        "start": 1795,
         "encoding": "bcd",
         "length": 4
       }
@@ -103,12 +105,12 @@
       "label": "Fourth Place",
       "short_label": "4th",
       "initials": {
-        "start": 1831,
+        "start": 1812,
         "encoding": "ch",
         "length": 3
       },
       "score": {
-        "start": 1818,
+        "start": 1799,
         "encoding": "bcd",
         "length": 4
       }
@@ -116,301 +118,283 @@
   ],
   "checksum8": [
     {
-      "start": 1626,
-      "end": 1801,
+      "start": 1600,
+      "end": 1783,
       "groupings": 4,
       "label": "Audits"
-    },
-    {
-      "start": 1513,
-      "end": 1524,
-      "groupings": 4,
-      "label": "Audits Continued"
     }
   ],
   "audits": {
     "Audits": {
       "01": {
-        "start": 1630,
+        "start": 1604,
         "encoding": "bcd",
         "length": 3,
         "label": "LEFT COINS"
       },
       "02": {
-        "start": 1634,
+        "start": 1608,
         "encoding": "bcd",
         "length": 3,
         "label": "CENTER COINS"
       },
       "03": {
-        "start": 1638,
+        "start": 1612,
         "encoding": "bcd",
         "length": 3,
         "label": "RIGHT COINS"
       },
       "04": {
-        "start": 1642,
+        "start": 1616,
         "encoding": "bcd",
         "length": 3,
         "label": "PAID CREDITS"
       },
       "05": {
-        "start": 1646,
+        "start": 1620,
         "encoding": "bcd",
         "length": 3,
         "label": "TOTAL PLAYS"
       },
       "06": {
-        "start": 1650,
+        "start": 1624,
         "encoding": "bcd",
         "length": 3,
         "label": "TOTAL FREE"
       },
       "08": {
-        "start": 1654,
+        "start": 1628,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY AWARDS"
       },
       "10": {
-        "start": 1658,
+        "start": 1632,
         "encoding": "bcd",
         "length": 3,
         "label": "SPECIAL AWARDS"
       },
       "12": {
-        "start": 1662,
+        "start": 1636,
         "encoding": "bcd",
         "length": 3,
         "label": "MATCH AWARDS"
       },
       "13": {
-        "start": 1666,
+        "start": 1640,
         "encoding": "bcd",
         "length": 3,
         "label": "H.S.T.D. CREDITS"
       },
       "15": {
-        "start": 1670,
+        "start": 1644,
         "encoding": "bcd",
         "length": 3,
-        "label": "SECOND CHANCES"
+        "label": "EXTRA BALLS"
       },
       "18": {
-        "start": 1674,
+        "start": 1648,
         "encoding": "bcd",
         "length": 3,
         "label": "MINUTES OF PLAY"
       },
       "19": {
-        "start": 1678,
+        "start": 1652,
         "encoding": "bcd",
         "length": 3,
         "label": "BALLS PLAYED"
       },
       "20": {
-        "start": 1682,
+        "start": 1656,
         "encoding": "bcd",
         "length": 3,
-        "label": "REPLAY1 AWARDS"
+        "label": "REPLAY 1 AWARDS"
       },
       "21": {
-        "start": 1686,
+        "start": 1660,
         "encoding": "bcd",
         "length": 3,
-        "label": "REPLAY2 AWARDS"
+        "label": "REPLAY 2 AWARDS"
       },
       "22": {
-        "start": 1690,
+        "start": 1664,
         "encoding": "bcd",
         "length": 3,
-        "label": "REPLAY3 AWARDS"
+        "label": "REPLAY 3 AWARDS"
       },
       "23": {
-        "start": 1694,
+        "start": 1668,
         "encoding": "bcd",
         "length": 3,
-        "label": "REPLAY4 AWARDS"
+        "label": "REPLAY 4 AWARDS"
       },
       "24": {
-        "start": 1698,
+        "start": 1672,
         "encoding": "bcd",
         "length": 3,
         "label": "1 PLAYER GAMES"
       },
       "25": {
-        "start": 1702,
+        "start": 1676,
         "encoding": "bcd",
         "length": 3,
         "label": "2 PLAYER GAMES"
       },
       "26": {
-        "start": 1706,
+        "start": 1680,
         "encoding": "bcd",
         "length": 3,
         "label": "3 PLAYER GAMES"
       },
       "27": {
-        "start": 1710,
+        "start": 1684,
         "encoding": "bcd",
         "length": 3,
         "label": "4 PLAYER GAMES"
       },
       "28": {
-        "start": 1714,
+        "start": 1688,
         "encoding": "bcd",
         "length": 3,
         "label": "BURN-IN CYCLES"
       },
       "29": {
-        "start": 1718,
+        "start": 1692,
         "encoding": "bcd",
         "length": 3,
-        "label": "JACKPOT AWARDS"
+        "label": "LEFT OUTLANE"
       },
       "30": {
-        "start": 1722,
+        "start": 1696,
         "encoding": "bcd",
         "length": 3,
-        "label": "ROULETTE WINS"
+        "label": "RIGHT OUTLANE"
       },
       "31": {
-        "start": 1726,
+        "start": 1700,
         "encoding": "bcd",
         "length": 3,
-        "label": "ROULETTE PLAYED"
+        "label": "FACE THE THING"
       },
       "32": {
-        "start": 1730,
+        "start": 1704,
         "encoding": "bcd",
         "length": 3,
-        "label": "WIN-METER AT TOP"
+        "label": "JACKPOTS"
       },
       "33": {
-        "start": 1734,
+        "start": 1708,
         "encoding": "bcd",
         "length": 3,
-        "label": "CASINO AWARDS"
+        "label": "3 BL. MULTI-BALLS"
       },
       "34": {
-        "start": 1738,
+        "start": 1712,
         "encoding": "bcd",
         "length": 3,
-        "label": "ROYAL FLUSH"
+        "label": "100K CENTER RAMP"
       },
       "35": {
-        "start": 1742,
+        "start": 1716,
         "encoding": "bcd",
         "length": 3,
-        "label": "21 AWARDS"
+        "label": "FIRE FIGHTS"
       },
       "36": {
-        "start": 1746,
+        "start": 1720,
         "encoding": "bcd",
         "length": 3,
-        "label": "SLOT SHOTS"
+        "label": "LIGHTNING RIDES"
       },
       "37": {
-        "start": 1750,
+        "start": 1724,
         "encoding": "bcd",
         "length": 3,
-        "label": "SKILL SHOTS"
+        "label": "2 BL. MULTI-BALLS"
       },
       "38": {
-        "start": 1754,
+        "start": 1728,
         "encoding": "bcd",
         "length": 3,
-        "label": "CONS. SEC. CHANCE"
+        "label": "MILLION SHOTS"
       },
       "39": {
-        "start": 1834,
+        "start": 1815,
         "encoding": "bcd",
         "length": 3,
-        "label": "H.S.RESET COUNTER"
+        "label": "H.S. RESET COUNTER"
       },
       "40": {
-        "start": 1758,
+        "start": 1736,
         "encoding": "bcd",
         "length": 3,
-        "label": "0.0-0.4 MIL. SCORE"
+        "label": "O.0-O.4 MIL. SCORE"
       },
       "41": {
-        "start": 1762,
+        "start": 1740,
         "encoding": "bcd",
         "length": 3,
-        "label": "0.5-0.9 MIL. SCORE"
+        "label": "O.5-O.9 MIL. SCORE"
       },
       "42": {
-        "start": 1766,
+        "start": 1744,
         "encoding": "bcd",
         "length": 3,
-        "label": "1.0-1.4 MIL. SCORE"
+        "label": "1.0-1.9 MIL. SCORE"
       },
       "43": {
-        "start": 1770,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "1.5-1.9 MIL. SCORE"
-      },
-      "44": {
-        "start": 1774,
+        "start": 1748,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.9 MIL. SCORE"
       },
-      "45": {
-        "start": 1778,
+      "44": {
+        "start": 1752,
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-3.9 MIL. SCORE"
       },
+      "45": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-5.9 MIL. SCORE"
+      },
       "46": {
-        "start": 1782,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "4.0-4.9 MIL. SCORE"
-      },
-      "47": {
-        "start": 1786,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "5.0-5.9 MIL. SCORE"
-      },
-      "48": {
-        "start": 1790,
+        "start": 1760,
         "encoding": "bcd",
         "length": 3,
         "label": "6.0-7.9 MIL. SCORE"
       },
-      "49": {
-        "start": 1794,
+      "47": {
+        "start": 1764,
         "encoding": "bcd",
         "length": 3,
-        "label": "8.0-9.9 MIL. SCORE"
+        "label": "8.0-99.9 MIL. SCORE"
       },
       "50": {
-        "start": 1798,
+        "start": 1768,
         "encoding": "bcd",
         "length": 3,
-        "label": "10-99.9 MIL. SCORE"
+        "label": "BONUS 2X REACHED"
+      },
+      "51": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS 3X REACHED"
       },
       "52": {
-        "start": 1513,
+        "start": 1776,
         "encoding": "bcd",
         "length": 3,
-        "label": "LEFT DRAINS"
+        "label": "BONUS 4X REACHED"
       },
       "53": {
-        "start": 1517,
+        "start": 1780,
         "encoding": "bcd",
         "length": 3,
-        "label": "RIGHT DRAINS"
-      },
-      "54": {
-        "start": 1521,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "MINUTES ON"
+        "label": "BONUS 5X REACHED"
       }
     }
   }

--- a/maps/williams/system11/f14_l1.nv.json
+++ b/maps/williams/system11/f14_l1.nv.json
@@ -1,5 +1,11 @@
 {
-  "_notes": "Compiled by Horsepin.",
+  "_notes": [
+    "Compiled by Horsepin.",
+    "F-14 Tomcat (Williams 1987)",
+    "https://www.ipdb.org/machine.cgi?id=804",
+    "Williams System 11A",
+    "2025-03 v0.2: Tom Collins added audits"
+  ],
   "_copyright": "Copyright (C) 2017 by Dave Horse <horse@horsesoft.uk>",
   "_license": "GNU Lesser General Public License v3.0",
   "_endian": "big",
@@ -8,7 +14,7 @@
     "f14_l1"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/f14_l1.nv.json
+++ b/maps/williams/system11/f14_l1.nv.json
@@ -118,5 +118,207 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI BALL"
+      },
+      "30": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS X"
+      },
+      "31": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LANDING"
+      },
+      "32": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "KILLS"
+      },
+      "33": {
+        "start": 1804,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "KILL LT XBALL"
+      },
+      "34": {
+        "start": 1808,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULT LT XBALL"
+      },
+      "35": {
+        "start": 1812,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FLIGHT INS COL"
+      },
+      "36": {
+        "start": 1816,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "37": {
+        "start": 1820,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
+      },
+      "38": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "KILLGEN YAGOV"
+      },
+      "39": {
+        "start": 1859,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/fire_l3.nv.json
+++ b/maps/williams/system11/fire_l3.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Fire! (Williams 1987)",
+    "https://www.ipdb.org/machine.cgi?id=859",
+    "Williams System 11A",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "fire_l3"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/fire_l3.nv.json
+++ b/maps/williams/system11/fire_l3.nv.json
@@ -120,5 +120,207 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1000000 AWARDED"
+      },
+      "30": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI BALL"
+      },
+      "31": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EX. BALL LIT"
+      },
+      "32": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL LIT"
+      },
+      "33": {
+        "start": 1804,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10X LIT"
+      },
+      "34": {
+        "start": 1808,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "100000 SH. LANE"
+      },
+      "35": {
+        "start": 1812,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL SH. LANE"
+      },
+      "36": {
+        "start": 1816,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CEN.RAMP RAISED"
+      },
+      "37": {
+        "start": 1820,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "P.O. FIRE AWARDED"
+      },
+      "38": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "NOT USED"
+      },
+      "39": {
+        "start": 1859,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/grand_l4.nv.json
+++ b/maps/williams/system11/grand_l4.nv.json
@@ -124,5 +124,207 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 BANK X BALLS"
+      },
+      "30": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MAXIMUM BONUSES"
+      },
+      "31": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "100K SCORES"
+      },
+      "32": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AWARDED SPEED50"
+      },
+      "33": {
+        "start": 1804,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2X MULT BALL"
+      },
+      "34": {
+        "start": 1808,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3X MULT BALL"
+      },
+      "35": {
+        "start": 1812,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS HOLDOVR"
+      },
+      "36": {
+        "start": 1816,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AUDIT 8"
+      },
+      "37": {
+        "start": 1820,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AUDIT 9"
+      },
+      "38": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AUDIT 10"
+      },
+      "39": {
+        "start": 1859,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/grand_l4.nv.json
+++ b/maps/williams/system11/grand_l4.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Grand Lizard (Williams 1986)",
+    "https://www.ipdb.org/machine.cgi?id=1070",
+    "Williams System 11",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "grand_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/gs_lu4.nv.json
+++ b/maps/williams/system11/gs_lu4.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "The Bally Game Show (Bally 1990)",
+    "https://www.ipdb.org/machine.cgi?id=985",
+    "Williams System 11C",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -11,7 +16,7 @@
     "gs_lu4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {

--- a/maps/williams/system11/gs_lu4.nv.json
+++ b/maps/williams/system11/gs_lu4.nv.json
@@ -121,6 +121,12 @@
       "end": 1801,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1494,
+      "end": 1501,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -388,6 +394,18 @@
         "encoding": "bcd",
         "length": 3,
         "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1494,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1498,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
       }
     }
   }

--- a/maps/williams/system11/gs_lu4.nv.json
+++ b/maps/williams/system11/gs_lu4.nv.json
@@ -122,5 +122,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1630,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1634,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1638,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1642,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1646,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1650,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1654,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1658,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1662,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1666,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1670,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1674,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1678,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1682,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1686,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1690,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1694,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1698,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1702,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1706,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1710,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1714,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1718,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE SPOT LETTER"
+      },
+      "30": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE MULTI-BALL"
+      },
+      "31": {
+        "start": 1726,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE GRAND PRIZE"
+      },
+      "32": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE BONUS 8 X"
+      },
+      "33": {
+        "start": 1734,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE OUTL EXBALL"
+      },
+      "34": {
+        "start": 1738,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "WHEEL EX.BALL LIT"
+      },
+      "35": {
+        "start": 1742,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "WHEEL 1 MILLION"
+      },
+      "36": {
+        "start": 1746,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "WHEEL 2 MILLION"
+      },
+      "37": {
+        "start": 1750,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "WHEEL BONUS HELD"
+      },
+      "38": {
+        "start": 1754,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE BIG BUCKS"
+      },
+      "39": {
+        "start": 1834,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1758,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1762,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1770,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1774,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1778,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1782,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1786,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1790,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1794,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/hs_l4.nv.json
+++ b/maps/williams/system11/hs_l4.nv.json
@@ -1,5 +1,10 @@
 {
-  "_notes": "Compiled by Tom Collins for initial development/testing purposes.",
+  "_notes": [
+    "Compiled by Tom Collins for initial development/testing purposes.",
+    "High Speed (Williams 1986)",
+    "https://www.ipdb.org/machine.cgi?id=1176",
+    "Williams System 11"
+  ],
   "_copyright": "Copyright (C) 2017 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
   "_endian": "big",

--- a/maps/williams/system11/jokrz_l6.nv.json
+++ b/maps/williams/system11/jokrz_l6.nv.json
@@ -123,5 +123,249 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1636,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1640,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1644,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1648,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT AWARDS"
+      },
+      "30": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 MILLION AWARDS"
+      },
+      "31": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DOUBLE YER SCORE"
+      },
+      "32": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTIBALLS"
+      },
+      "33": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EJECT'S SPECIAL"
+      },
+      "34": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LANE EX. BALLS"
+      },
+      "35": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ADVANCE 'X'S"
+      },
+      "36": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALL LIT"
+      },
+      "37": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BELLS COMPLETED"
+      },
+      "38": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL LIT"
+      },
+      "39": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.4 MIL. SCORE"
+      },
+      "45": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.5-2.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-99.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/jokrz_l6.nv.json
+++ b/maps/williams/system11/jokrz_l6.nv.json
@@ -3,7 +3,8 @@
     "Compiled by Francis De Brabandere.",
     "Jokerz! (Williams 1988)",
     "https://www.ipdb.org/machine.cgi?id=1308",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "jokrz_l6"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/jokrz_l6.nv.json
+++ b/maps/williams/system11/jokrz_l6.nv.json
@@ -122,6 +122,12 @@
       "end": 1791,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1461,
+      "end": 1476,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -365,6 +371,30 @@
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1461,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1465,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
+      },
+      "54": {
+        "start": 1469,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MILLION LIT"
+      },
+      "55": {
+        "start": 1473,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONSOL. EX. BALLS"
       }
     }
   }

--- a/maps/williams/system11/milln_l3.nv.json
+++ b/maps/williams/system11/milln_l3.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Millionaire (Williams 1987)",
+    "https://www.ipdb.org/machine.cgi?id=1597",
+    "Williams System 11A",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "milln_l3"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/milln_l3.nv.json
+++ b/maps/williams/system11/milln_l3.nv.json
@@ -120,5 +120,207 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "C.B. SPIN PERCENT"
+      },
+      "30": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL PERCENT"
+      },
+      "31": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EX. BALL PERCENT"
+      },
+      "32": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EMERALD AWARDS"
+      },
+      "33": {
+        "start": 1804,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RUBY AWARDS"
+      },
+      "34": {
+        "start": 1808,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DIAMOND AWARDS"
+      },
+      "35": {
+        "start": 1812,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "C.B. SPIN SPINS"
+      },
+      "36": {
+        "start": 1816,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES \"ON\""
+      },
+      "37": {
+        "start": 1820,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "C.B. SPIN EX. BALL"
+      },
+      "38": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "GOLD/$ EX. BALL"
+      },
+      "39": {
+        "start": 1859,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/mousn_l4.nv.json
+++ b/maps/williams/system11/mousn_l4.nv.json
@@ -123,5 +123,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1631,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1635,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1639,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1643,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1647,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1651,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1655,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1659,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1663,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1667,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1671,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "17": {
+        "start": 1675,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVG. BALL TIME"
+      },
+      "18": {
+        "start": 1679,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1683,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1687,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1691,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1695,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1699,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1703,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1707,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1711,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1715,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1719,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1723,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTIBALLS"
+      },
+      "30": {
+        "start": 1727,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT AWARDS"
+      },
+      "31": {
+        "start": 1731,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MILLION AWARDS"
+      },
+      "32": {
+        "start": 1735,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CHEEZ. BON. AWARDS"
+      },
+      "33": {
+        "start": 1739,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DOUBLE PLAYFIELD"
+      },
+      "34": {
+        "start": 1743,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2X MULT. AWARDS"
+      },
+      "35": {
+        "start": 1747,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3X MULT. AWARDS"
+      },
+      "36": {
+        "start": 1751,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "OUTLANE AWARDS"
+      },
+      "37": {
+        "start": 1755,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONSOL. EX. BALLS"
+      },
+      "38": {
+        "start": 1759,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CHEEZY EX. BALLS"
+      },
+      "39": {
+        "start": 1835,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S. RESET COUNTER"
+      },
+      "40": {
+        "start": 1763,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1767,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1771,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1775,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1779,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1783,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1787,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1791,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1795,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1799,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/mousn_l4.nv.json
+++ b/maps/williams/system11/mousn_l4.nv.json
@@ -122,6 +122,12 @@
       "end": 1802,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1495,
+      "end": 1502,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -192,134 +198,128 @@
         "length": 3,
         "label": "EXTRA BALLS"
       },
-      "17": {
-        "start": 1675,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "AVG. BALL TIME"
-      },
       "18": {
-        "start": 1679,
+        "start": 1675,
         "encoding": "bcd",
         "length": 3,
         "label": "MINUTES OF PLAY"
       },
       "19": {
-        "start": 1683,
+        "start": 1679,
         "encoding": "bcd",
         "length": 3,
         "label": "BALLS PLAYED"
       },
       "20": {
-        "start": 1687,
+        "start": 1683,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY1 AWARDS"
       },
       "21": {
-        "start": 1691,
+        "start": 1687,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY2 AWARDS"
       },
       "22": {
-        "start": 1695,
+        "start": 1691,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY3 AWARDS"
       },
       "23": {
-        "start": 1699,
+        "start": 1695,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY4 AWARDS"
       },
       "24": {
-        "start": 1703,
+        "start": 1699,
         "encoding": "bcd",
         "length": 3,
         "label": "1 PLAYER GAMES"
       },
       "25": {
-        "start": 1707,
+        "start": 1703,
         "encoding": "bcd",
         "length": 3,
         "label": "2 PLAYER GAMES"
       },
       "26": {
-        "start": 1711,
+        "start": 1707,
         "encoding": "bcd",
         "length": 3,
         "label": "3 PLAYER GAMES"
       },
       "27": {
-        "start": 1715,
+        "start": 1711,
         "encoding": "bcd",
         "length": 3,
         "label": "4 PLAYER GAMES"
       },
       "28": {
-        "start": 1719,
+        "start": 1715,
         "encoding": "bcd",
         "length": 3,
         "label": "BURN-IN CYCLES"
       },
       "29": {
-        "start": 1723,
+        "start": 1719,
         "encoding": "bcd",
         "length": 3,
         "label": "MULTIBALLS"
       },
       "30": {
-        "start": 1727,
+        "start": 1723,
         "encoding": "bcd",
         "length": 3,
         "label": "JACKPOT AWARDS"
       },
       "31": {
-        "start": 1731,
+        "start": 1727,
         "encoding": "bcd",
         "length": 3,
         "label": "MILLION AWARDS"
       },
       "32": {
-        "start": 1735,
+        "start": 1731,
         "encoding": "bcd",
         "length": 3,
         "label": "CHEEZ. BON. AWARDS"
       },
       "33": {
-        "start": 1739,
+        "start": 1735,
         "encoding": "bcd",
         "length": 3,
         "label": "DOUBLE PLAYFIELD"
       },
       "34": {
-        "start": 1743,
+        "start": 1739,
         "encoding": "bcd",
         "length": 3,
         "label": "2X MULT. AWARDS"
       },
       "35": {
-        "start": 1747,
+        "start": 1743,
         "encoding": "bcd",
         "length": 3,
         "label": "3X MULT. AWARDS"
       },
       "36": {
-        "start": 1751,
+        "start": 1747,
         "encoding": "bcd",
         "length": 3,
         "label": "OUTLANE AWARDS"
       },
       "37": {
-        "start": 1755,
+        "start": 1751,
         "encoding": "bcd",
         "length": 3,
         "label": "CONSOL. EX. BALLS"
       },
       "38": {
-        "start": 1759,
+        "start": 1755,
         "encoding": "bcd",
         "length": 3,
         "label": "CHEEZY EX. BALLS"
@@ -331,64 +331,82 @@
         "label": "H.S. RESET COUNTER"
       },
       "40": {
-        "start": 1763,
+        "start": 1759,
         "encoding": "bcd",
         "length": 3,
         "label": "0.0-0.4 MIL. SCORE"
       },
       "41": {
-        "start": 1767,
+        "start": 1763,
         "encoding": "bcd",
         "length": 3,
         "label": "0.5-0.9 MIL. SCORE"
       },
       "42": {
-        "start": 1771,
+        "start": 1767,
         "encoding": "bcd",
         "length": 3,
         "label": "1.0-1.4 MIL. SCORE"
       },
       "43": {
-        "start": 1775,
+        "start": 1771,
         "encoding": "bcd",
         "length": 3,
         "label": "1.5-1.9 MIL. SCORE"
       },
       "44": {
-        "start": 1779,
+        "start": 1775,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.9 MIL. SCORE"
       },
       "45": {
-        "start": 1783,
+        "start": 1779,
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-3.9 MIL. SCORE"
       },
       "46": {
-        "start": 1787,
+        "start": 1783,
         "encoding": "bcd",
         "length": 3,
         "label": "4.0-4.9 MIL. SCORE"
       },
       "47": {
-        "start": 1791,
+        "start": 1787,
         "encoding": "bcd",
         "length": 3,
         "label": "5.0-5.9 MIL. SCORE"
       },
       "48": {
-        "start": 1795,
+        "start": 1791,
         "encoding": "bcd",
         "length": 3,
         "label": "6.0-7.9 MIL. SCORE"
       },
       "49": {
-        "start": 1799,
+        "start": 1795,
         "encoding": "bcd",
         "length": 3,
         "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1799,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1495,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1499,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
       }
     }
   }

--- a/maps/williams/system11/mousn_l4.nv.json
+++ b/maps/williams/system11/mousn_l4.nv.json
@@ -1,9 +1,10 @@
 {
   "_notes": [
     "Compiled by Francis De Brabandere.",
-    "Mousin' Around! (Williams 1989)",
+    "Mousin' Around! (Bally 1989)",
     "https://www.ipdb.org/machine.cgi?id=1635",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "mousn_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/pb_l5.nv.json
+++ b/maps/williams/system11/pb_l5.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "PIN*BOT (Williams 1986)",
+    "https://www.ipdb.org/machine.cgi?id=1796",
+    "Williams System 11A",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "pb_l5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/pb_l5.nv.json
+++ b/maps/williams/system11/pb_l5.nv.json
@@ -121,5 +121,207 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "D.T. PERCENT"
+      },
+      "30": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SOLAR PERCENT"
+      },
+      "31": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ENERGY PERCENT"
+      },
+      "32": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "S. EJECT PERCENT"
+      },
+      "33": {
+        "start": 1804,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REACH PERCENT"
+      },
+      "34": {
+        "start": 1808,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SOLAR AWARDS"
+      },
+      "35": {
+        "start": 1812,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ENERGY AWARDS"
+      },
+      "36": {
+        "start": 1816,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REACH AWARDS"
+      },
+      "37": {
+        "start": 1820,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CHEST EX. BALL"
+      },
+      "38": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "S. EJECT EX. BALL"
+      },
+      "39": {
+        "start": 1859,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/polic_l4.nv.json
+++ b/maps/williams/system11/polic_l4.nv.json
@@ -123,6 +123,12 @@
       "end": 1802,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1515,
+      "end": 1522,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -390,6 +396,18 @@
         "encoding": "bcd",
         "length": 3,
         "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1515,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1519,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
       }
     }
   }

--- a/maps/williams/system11/polic_l4.nv.json
+++ b/maps/williams/system11/polic_l4.nv.json
@@ -4,7 +4,8 @@
     "Police Force (Williams 1989)",
     "https://www.ipdb.org/machine.cgi?id=1841",
     "Williams System 11B",
-    "Same layout as Mousin' Around!"
+    "Same layout as Mousin' Around!",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -14,7 +15,7 @@
     "polic_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/polic_l4.nv.json
+++ b/maps/williams/system11/polic_l4.nv.json
@@ -124,5 +124,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1631,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1635,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1639,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1643,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1647,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1651,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1655,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1659,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1663,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1667,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1671,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1675,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1679,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1683,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1687,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1691,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1695,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1699,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1703,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1707,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1711,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1715,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1719,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT AWARDS"
+      },
+      "30": {
+        "start": 1723,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "UNLIMITD MILLION"
+      },
+      "31": {
+        "start": 1727,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MILLIONS AWARDED"
+      },
+      "32": {
+        "start": 1731,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TAKE HIGHEST"
+      },
+      "33": {
+        "start": 1735,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTIBALLS"
+      },
+      "34": {
+        "start": 1739,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ADVANCE X'S"
+      },
+      "35": {
+        "start": 1743,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "'X' SPECIAL"
+      },
+      "36": {
+        "start": 1747,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOP COP AWARDS"
+      },
+      "37": {
+        "start": 1751,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONSOL. EX. BALLS"
+      },
+      "38": {
+        "start": 1755,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOP EXTRA BALLS"
+      },
+      "39": {
+        "start": 1835,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1759,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1763,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1767,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1771,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1775,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1779,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1783,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1787,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1791,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1795,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1799,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/pool_l7.nv.json
+++ b/maps/williams/system11/pool_l7.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Pool Sharks (Bally 1990)",
+    "https://www.ipdb.org/machine.cgi?id=1848",
+    "Williams System 11C",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "pool_l7"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {

--- a/maps/williams/system11/pool_l7.nv.json
+++ b/maps/williams/system11/pool_l7.nv.json
@@ -169,6 +169,12 @@
       "end": 1801,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1510,
+      "end": 1517,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -221,221 +227,233 @@
         "length": 3,
         "label": "NOT USED"
       },
-      "11": {
-        "start": 1662,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "NOT USED"
-      },
       "12": {
-        "start": 1666,
+        "start": 1662,
         "encoding": "bcd",
         "length": 3,
         "label": "MATCH AWARDS"
       },
       "13": {
-        "start": 1670,
+        "start": 1666,
         "encoding": "bcd",
         "length": 3,
         "label": "H.S.T.D. CREDITS"
       },
       "15": {
-        "start": 1674,
+        "start": 1670,
         "encoding": "bcd",
         "length": 3,
         "label": "EXTRA BALLS"
       },
       "18": {
-        "start": 1678,
+        "start": 1674,
         "encoding": "bcd",
         "length": 3,
         "label": "MINUTES OF PLAY"
       },
       "19": {
-        "start": 1682,
+        "start": 1678,
         "encoding": "bcd",
         "length": 3,
         "label": "BALLS PLAYED"
       },
       "20": {
-        "start": 1686,
+        "start": 1682,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY1 AWARDS"
       },
       "21": {
-        "start": 1690,
+        "start": 1686,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY2 AWARDS"
       },
       "22": {
-        "start": 1694,
+        "start": 1690,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY3 AWARDS"
       },
       "23": {
-        "start": 1698,
+        "start": 1694,
         "encoding": "bcd",
         "length": 3,
         "label": "REPLAY4 AWARDS"
       },
       "24": {
-        "start": 1702,
+        "start": 1698,
         "encoding": "bcd",
         "length": 3,
         "label": "1 PLAYER GAMES"
       },
       "25": {
-        "start": 1706,
+        "start": 1702,
         "encoding": "bcd",
         "length": 3,
         "label": "2 PLAYER GAMES"
       },
       "26": {
-        "start": 1710,
+        "start": 1706,
         "encoding": "bcd",
         "length": 3,
         "label": "3 PLAYER GAMES"
       },
       "27": {
-        "start": 1714,
+        "start": 1710,
         "encoding": "bcd",
         "length": 3,
         "label": "4 PLAYER GAMES"
       },
       "28": {
-        "start": 1718,
+        "start": 1714,
         "encoding": "bcd",
         "length": 3,
         "label": "BURN-IN CYCLES"
       },
       "29": {
-        "start": 1722,
+        "start": 1718,
         "encoding": "bcd",
         "length": 3,
         "label": "JACKPOT MADE"
       },
       "30": {
-        "start": 1726,
+        "start": 1722,
         "encoding": "bcd",
         "length": 3,
         "label": "TRICK SHOT 8BALL"
       },
       "31": {
-        "start": 1730,
+        "start": 1726,
         "encoding": "bcd",
         "length": 3,
         "label": "TRICK SHOT 9BALL"
       },
       "32": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CUESTICK < MILL"
+      },
+      "33": {
         "start": 1734,
         "encoding": "bcd",
         "length": 3,
-        "label": "CUESTICK ? MILL"
-      },
-      "33": {
-        "start": 1738,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "CUESTICK ?? MILL"
+        "label": "CUESTICK >= MILL"
       },
       "34": {
-        "start": 1742,
+        "start": 1738,
         "encoding": "bcd",
         "length": 3,
         "label": "RACKS 8 BALL"
       },
       "35": {
-        "start": 1746,
+        "start": 1742,
         "encoding": "bcd",
         "length": 3,
         "label": "RACKS 9 BALL"
       },
       "36": {
-        "start": 1750,
+        "start": 1746,
         "encoding": "bcd",
         "length": 3,
         "label": "CONS. EX. BALLS"
       },
       "37": {
-        "start": 1754,
+        "start": 1750,
         "encoding": "bcd",
         "length": 3,
         "label": "BONUS MULTIPLIER"
       },
       "38": {
-        "start": 1758,
+        "start": 1754,
         "encoding": "bcd",
         "length": 3,
         "label": "POWER SHOT AWARD"
       },
       "39": {
-        "start": 1499,
+        "start": 1834,
         "encoding": "bcd",
         "length": 3,
         "label": "H.S.RESET COUNTER"
       },
       "40": {
-        "start": 1762,
+        "start": 1758,
         "encoding": "bcd",
         "length": 3,
         "label": "0.0-0.4 MIL. SCORE"
       },
       "41": {
-        "start": 1766,
+        "start": 1762,
         "encoding": "bcd",
         "length": 3,
         "label": "0.5-0.9 MIL. SCORE"
       },
       "42": {
-        "start": 1770,
+        "start": 1766,
         "encoding": "bcd",
         "length": 3,
         "label": "1.0-1.4 MIL. SCORE"
       },
       "43": {
-        "start": 1774,
+        "start": 1770,
         "encoding": "bcd",
         "length": 3,
         "label": "1.5-1.9 MIL. SCORE"
       },
       "44": {
-        "start": 1778,
+        "start": 1774,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.9 MIL. SCORE"
       },
       "45": {
-        "start": 1782,
+        "start": 1778,
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-3.9 MIL. SCORE"
       },
       "46": {
-        "start": 1786,
+        "start": 1782,
         "encoding": "bcd",
         "length": 3,
         "label": "4.0-4.9 MIL. SCORE"
       },
       "47": {
-        "start": 1790,
+        "start": 1786,
         "encoding": "bcd",
         "length": 3,
         "label": "5.0-5.9 MIL. SCORE"
       },
       "48": {
-        "start": 1794,
+        "start": 1790,
         "encoding": "bcd",
         "length": 3,
         "label": "6.0-7.9 MIL. SCORE"
       },
       "49": {
-        "start": 1798,
+        "start": 1794,
         "encoding": "bcd",
         "length": 3,
         "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1510,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1514,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
       }
     }
   }

--- a/maps/williams/system11/pool_l7.nv.json
+++ b/maps/williams/system11/pool_l7.nv.json
@@ -170,5 +170,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1630,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1634,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1638,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1642,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1646,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1650,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1654,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1658,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "NOT USED"
+      },
+      "11": {
+        "start": 1662,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "NOT USED"
+      },
+      "12": {
+        "start": 1666,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1670,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1674,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1678,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1682,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1686,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1690,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1694,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1698,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1702,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1706,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1710,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1714,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1718,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT MADE"
+      },
+      "30": {
+        "start": 1726,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TRICK SHOT 8BALL"
+      },
+      "31": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TRICK SHOT 9BALL"
+      },
+      "32": {
+        "start": 1734,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CUESTICK ? MILL"
+      },
+      "33": {
+        "start": 1738,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CUESTICK ?? MILL"
+      },
+      "34": {
+        "start": 1742,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RACKS 8 BALL"
+      },
+      "35": {
+        "start": 1746,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RACKS 9 BALL"
+      },
+      "36": {
+        "start": 1750,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONS. EX. BALLS"
+      },
+      "37": {
+        "start": 1754,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS MULTIPLIER"
+      },
+      "38": {
+        "start": 1758,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "POWER SHOT AWARD"
+      },
+      "39": {
+        "start": 1499,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1762,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1770,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1774,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1778,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1782,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1786,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1790,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1794,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/radcl_l1.nv.json
+++ b/maps/williams/system11/radcl_l1.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Radical! (Bally 1990)",
+    "https://www.ipdb.org/machine.cgi?id=1904",
+    "Williams System 11C",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "radcl_l1"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {

--- a/maps/williams/system11/radcl_l1.nv.json
+++ b/maps/williams/system11/radcl_l1.nv.json
@@ -121,5 +121,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1630,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1634,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1638,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1642,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1646,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1650,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1654,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1658,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1662,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1666,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1670,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1674,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1678,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1682,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1686,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1690,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1694,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1698,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1702,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1706,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1710,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1714,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1718,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE 4 RADS"
+      },
+      "30": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE MULTI-BALL"
+      },
+      "31": {
+        "start": 1726,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE MEGA MILL."
+      },
+      "32": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE BONUS 5X"
+      },
+      "33": {
+        "start": 1734,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE TOP MILLION"
+      },
+      "34": {
+        "start": 1738,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS 1 MILLION"
+      },
+      "35": {
+        "start": 1742,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RAD MILLION"
+      },
+      "36": {
+        "start": 1746,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LIT LOOP EXBALL"
+      },
+      "37": {
+        "start": 1750,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE SNAKE RUN"
+      },
+      "38": {
+        "start": 1754,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MADE CON. EXBALL"
+      },
+      "39": {
+        "start": 1834,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1758,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1762,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1770,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1774,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1778,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1782,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1786,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1790,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1794,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/radcl_l1.nv.json
+++ b/maps/williams/system11/radcl_l1.nv.json
@@ -120,6 +120,12 @@
       "end": 1801,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1519,
+      "end": 1526,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -387,6 +393,18 @@
         "encoding": "bcd",
         "length": 3,
         "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1519,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1523,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
       }
     }
   }

--- a/maps/williams/system11/rdkng_l4.nv.json
+++ b/maps/williams/system11/rdkng_l4.nv.json
@@ -120,5 +120,207 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI BALLS"
+      },
+      "30": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TIME LOCKS"
+      },
+      "31": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MEGA SCORES"
+      },
+      "32": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DETOUR EX.BALLS"
+      },
+      "33": {
+        "start": 1804,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "R. RAMP EX.BALLS"
+      },
+      "34": {
+        "start": 1808,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BONUS HOLDS"
+      },
+      "35": {
+        "start": 1812,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONSOL. EX.BALLS"
+      },
+      "36": {
+        "start": 1816,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DET.EXB. LIT"
+      },
+      "37": {
+        "start": 1820,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL LIT"
+      },
+      "38": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ATT.MODE CYCLES"
+      },
+      "39": {
+        "start": 1859,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/rdkng_l4.nv.json
+++ b/maps/williams/system11/rdkng_l4.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Road Kings (Williams 1986)",
+    "https://www.ipdb.org/machine.cgi?id=1970",
+    "Williams System 11",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "rdkng_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/rollr_l2.nv.json
+++ b/maps/williams/system11/rollr_l2.nv.json
@@ -120,5 +120,291 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1586,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1590,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1594,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1598,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1602,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1606,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1610,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1614,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1618,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1622,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1626,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1630,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1634,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1638,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 1 AWARDS"
+      },
+      "21": {
+        "start": 1642,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 2 AWARDS"
+      },
+      "22": {
+        "start": 1646,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 3 AWARDS"
+      },
+      "23": {
+        "start": 1650,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 4 AWARDS"
+      },
+      "24": {
+        "start": 1654,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1658,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1662,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1666,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1670,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1674,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "30": {
+        "start": 1678,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT KICKBACKS"
+      },
+      "31": {
+        "start": 1682,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
+      },
+      "32": {
+        "start": 1686,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL RAMP SHOTS"
+      },
+      "33": {
+        "start": 1690,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DEEP FREEZE PLAY"
+      },
+      "34": {
+        "start": 1694,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SKATE COMPLETE"
+      },
+      "35": {
+        "start": 1698,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOP DROPS COMP."
+      },
+      "36": {
+        "start": 1702,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ALL TEAMS COMP."
+      },
+      "37": {
+        "start": 1706,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTIBALLS"
+      },
+      "38": {
+        "start": 1710,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOTS"
+      },
+      "39": {
+        "start": 1801,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S. RESET COUNTER"
+      },
+      "40": {
+        "start": 1714,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1718,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.9 MIL. SCORE"
+      },
+      "43": {
+        "start": 1726,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1734,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-5.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1738,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1742,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-99.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1746,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FIRST REPLAY IS"
+      },
+      "49": {
+        "start": 1750,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVG. GAME 200 MIN."
+      },
+      "50": {
+        "start": 1754,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SUDDEN DEATH"
+      },
+      "51": {
+        "start": 1758,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SUDDN. DEATH RMPS."
+      },
+      "52": {
+        "start": 1762,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SUDDN. DEATH COMP."
+      },
+      "53": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ROLLER MOTION"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/rollr_l2.nv.json
+++ b/maps/williams/system11/rollr_l2.nv.json
@@ -322,88 +322,82 @@
         "label": "H.S. RESET COUNTER"
       },
       "40": {
-        "start": 1714,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "O.0-O.4 MIL. SCORE"
-      },
-      "41": {
         "start": 1718,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 MIL. SCORE"
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
       },
       "42": {
-        "start": 1722,
+        "start": 1726,
         "encoding": "bcd",
         "length": 3,
         "label": "1.0-1.9 MIL. SCORE"
       },
       "43": {
-        "start": 1726,
+        "start": 1730,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.9 MIL. SCORE"
       },
       "44": {
-        "start": 1730,
+        "start": 1734,
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-3.9 MIL. SCORE"
       },
       "45": {
-        "start": 1734,
+        "start": 1738,
         "encoding": "bcd",
         "length": 3,
         "label": "4.0-5.9 MIL. SCORE"
       },
       "46": {
-        "start": 1738,
+        "start": 1742,
         "encoding": "bcd",
         "length": 3,
         "label": "6.0-7.9 MIL. SCORE"
       },
       "47": {
-        "start": 1742,
+        "start": 1746,
         "encoding": "bcd",
         "length": 3,
         "label": "8.0-99.9 MIL. SCORE"
       },
-      "48": {
-        "start": 1746,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "FIRST REPLAY IS"
-      },
-      "49": {
-        "start": 1750,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "AVG. GAME 200 MIN."
-      },
       "50": {
-        "start": 1754,
+        "start": 1750,
         "encoding": "bcd",
         "length": 3,
         "label": "SUDDEN DEATH"
       },
       "51": {
-        "start": 1758,
+        "start": 1754,
         "encoding": "bcd",
         "length": 3,
         "label": "SUDDN. DEATH RMPS."
       },
       "52": {
-        "start": 1762,
+        "start": 1758,
         "encoding": "bcd",
         "length": 3,
         "label": "SUDDN. DEATH COMP."
       },
       "53": {
-        "start": 1766,
+        "start": 1762,
         "encoding": "bcd",
         "length": 3,
         "label": "ROLLER MOTION"
+      },
+      "54": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES ON"
       }
     }
   }

--- a/maps/williams/system11/rollr_l2.nv.json
+++ b/maps/williams/system11/rollr_l2.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Rollergames (Williams 1990)",
+    "https://www.ipdb.org/machine.cgi?id=2006",
+    "Williams System 11C",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "rollr_l2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/rvrbt_l3.nv.json
+++ b/maps/williams/system11/rvrbt_l3.nv.json
@@ -121,5 +121,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1630,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1634,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1638,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1642,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1646,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1650,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1654,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1658,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1662,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1666,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1670,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SECOND CHANCES"
+      },
+      "16": {
+        "start": 1674,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PERCT. SEC. CHANCE"
+      },
+      "18": {
+        "start": 1678,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1682,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1686,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1690,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1694,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1698,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1702,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1706,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1710,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1714,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1718,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1722,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT AWARDS"
+      },
+      "30": {
+        "start": 1726,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ROULETTE WINS"
+      },
+      "31": {
+        "start": 1730,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ROULETTE PLAYED"
+      },
+      "32": {
+        "start": 1734,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "WIN-METER AT TOP"
+      },
+      "33": {
+        "start": 1738,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CASINO AWARDS"
+      },
+      "34": {
+        "start": 1742,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ROYAL FLUSH"
+      },
+      "35": {
+        "start": 1746,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "21 AWARDS"
+      },
+      "36": {
+        "start": 1750,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SLOT SHOTS"
+      },
+      "37": {
+        "start": 1754,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SKILL SHOTS"
+      },
+      "38": {
+        "start": 1758,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CONS. SEC. CHANCE"
+      },
+      "39": {
+        "start": 1834,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1762,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1766,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1770,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1774,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1778,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1782,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1786,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1790,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1794,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1798,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/rvrbt_l3.nv.json
+++ b/maps/williams/system11/rvrbt_l3.nv.json
@@ -1,6 +1,11 @@
 {
   "_notes": [
-    "Compiled by Tom Collins using template-s11.json."
+    "Compiled by Tom Collins using template-s11.json.",
+    "Riverboat Gambler (Williams 1990)",
+    "https://www.ipdb.org/machine.cgi?id=1966",
+    "Williams System 11C",
+    "2025-02 v0.1: Initial version",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -10,7 +15,7 @@
     "rvrbt_l3"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {

--- a/maps/williams/system11/spstn_l5.nv.json
+++ b/maps/williams/system11/spstn_l5.nv.json
@@ -328,13 +328,13 @@
         "start": 1812,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.0-O.4 M. SCORE"
+        "label": "0.0-0.4 M. SCORE"
       },
       "41": {
         "start": 1816,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 M. SCORE"
+        "label": "0.5-0.9 M. SCORE"
       },
       "42": {
         "start": 1820,

--- a/maps/williams/system11/spstn_l5.nv.json
+++ b/maps/williams/system11/spstn_l5.nv.json
@@ -3,7 +3,8 @@
     "Compiled by Francis De Brabandere.",
     "Space Station (Williams 1987)",
     "https://www.ipdb.org/machine.cgi?id=2261",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "spstn_l5"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/spstn_l5.nv.json
+++ b/maps/williams/system11/spstn_l5.nv.json
@@ -123,5 +123,237 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SHUTTLE BANK"
+      },
+      "30": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "STATION BANK"
+      },
+      "31": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI BALL"
+      },
+      "32": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAIN"
+      },
+      "33": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAIN"
+      },
+      "34": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 BANK"
+      },
+      "35": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT AWARDED"
+      },
+      "36": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "DROP TG EX. BALL"
+      },
+      "37": {
+        "start": 1804,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL BY USA"
+      },
+      "38": {
+        "start": 1808,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BUMPER 3000"
+      },
+      "39": {
+        "start": 1863,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1812,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 M. SCORE"
+      },
+      "41": {
+        "start": 1816,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 M. SCORE"
+      },
+      "42": {
+        "start": 1820,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 M. SCORE"
+      },
+      "43": {
+        "start": 1824,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 M. SCORE"
+      },
+      "44": {
+        "start": 1828,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.4 M. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/swrds_l2.nv.json
+++ b/maps/williams/system11/swrds_l2.nv.json
@@ -329,13 +329,13 @@
         "start": 1780,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.0-O.4 M. SCORE"
+        "label": "0.0-0.4 M. SCORE"
       },
       "41": {
         "start": 1784,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 M. SCORE"
+        "label": "0.5-0.9 M. SCORE"
       },
       "42": {
         "start": 1788,

--- a/maps/williams/system11/swrds_l2.nv.json
+++ b/maps/williams/system11/swrds_l2.nv.json
@@ -4,7 +4,8 @@
     "Swords of Fury (Williams 1988)",
     "https://www.ipdb.org/machine.cgi?id=2486",
     "Williams System 11B",
-    "Same layout as Mousin' Around!"
+    "Same layout as Mousin' Around!",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -14,7 +15,7 @@
     "swrds_l2"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/swrds_l2.nv.json
+++ b/maps/williams/system11/swrds_l2.nv.json
@@ -124,5 +124,243 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HSTD CREDITS"
+      },
+      "15": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MIN. OF PLAY"
+      },
+      "19": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYR. GAMES"
+      },
+      "25": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYR. GAMES"
+      },
+      "26": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYR. GAMES"
+      },
+      "27": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYR. GAMES"
+      },
+      "28": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN IN CYCLES"
+      },
+      "29": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT OUTLANE"
+      },
+      "30": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT OUTLANE"
+      },
+      "31": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVENGER MADE"
+      },
+      "32": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EX. BALL LIT"
+      },
+      "33": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "7 X LIT"
+      },
+      "34": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL LIT"
+      },
+      "35": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI- BALL"
+      },
+      "36": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LIONMAN BONUS"
+      },
+      "37": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOP.LOOP 500000"
+      },
+      "38": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT MADE"
+      },
+      "39": {
+        "start": 1835,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 M. SCORE"
+      },
+      "41": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 M. SCORE"
+      },
+      "42": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 M. SCORE"
+      },
+      "43": {
+        "start": 1792,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 M. SCORE"
+      },
+      "44": {
+        "start": 1796,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.4 M. SCORE"
+      },
+      "45": {
+        "start": 1800,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.5-9.9 M. SCORE"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/taxi_l4.nv.json
+++ b/maps/williams/system11/taxi_l4.nv.json
@@ -123,5 +123,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1620,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1624,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1628,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1632,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1636,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1640,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1644,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1648,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1652,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1656,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1660,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1664,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1668,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1672,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 1 AWARDS"
+      },
+      "21": {
+        "start": 1676,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 2 AWARDS"
+      },
+      "22": {
+        "start": 1680,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 3 AWARDS"
+      },
+      "23": {
+        "start": 1684,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY 4 AWARDS"
+      },
+      "24": {
+        "start": 1688,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1692,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1696,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1700,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1704,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1708,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT OUTLANE"
+      },
+      "30": {
+        "start": 1712,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT OUTLANE"
+      },
+      "31": {
+        "start": 1716,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MILLION SHOTS"
+      },
+      "32": {
+        "start": 1720,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACKPOT SHOTS"
+      },
+      "33": {
+        "start": 1724,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MULTI-BALLS"
+      },
+      "34": {
+        "start": 1728,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "E.B. VIA CATAPULT"
+      },
+      "35": {
+        "start": 1732,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPINOUT 100K"
+      },
+      "36": {
+        "start": 1736,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JACK / MIL GAMES"
+      },
+      "37": {
+        "start": 1740,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TIME LOCKS"
+      },
+      "38": {
+        "start": 1744,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "JOYRIDES"
+      },
+      "39": {
+        "start": 1823,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S. RESET COUNTER"
+      },
+      "40": {
+        "start": 1748,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.0-O.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1752,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "O.5-O.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1756,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.9 MIL. SCORE"
+      },
+      "43": {
+        "start": 1760,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1764,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1768,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-5.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1772,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1776,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-99.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1780,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "FIRST REPLAY IS"
+      },
+      "49": {
+        "start": 1784,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "AVG. GAME 200 MIN."
+      },
+      "50": {
+        "start": 1788,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "HI. SCR. 3 CREDITS"
+      }
+    }
+  }
 }

--- a/maps/williams/system11/taxi_l4.nv.json
+++ b/maps/williams/system11/taxi_l4.nv.json
@@ -283,7 +283,7 @@
         "label": "JACKPOT SHOTS"
       },
       "33": {
-        "start": 1724,
+        "start": 1748,
         "encoding": "bcd",
         "length": 3,
         "label": "MULTI-BALLS"
@@ -325,70 +325,52 @@
         "label": "H.S. RESET COUNTER"
       },
       "40": {
-        "start": 1748,
+        "start": 1760,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.0-O.4 MIL. SCORE"
+        "label": "0.0-0.4 MIL. SCORE"
       },
       "41": {
-        "start": 1752,
+        "start": 1764,
         "encoding": "bcd",
         "length": 3,
-        "label": "O.5-O.9 MIL. SCORE"
+        "label": "0.5-0.9 MIL. SCORE"
       },
       "42": {
-        "start": 1756,
+        "start": 1768,
         "encoding": "bcd",
         "length": 3,
         "label": "1.0-1.9 MIL. SCORE"
       },
       "43": {
-        "start": 1760,
+        "start": 1772,
         "encoding": "bcd",
         "length": 3,
         "label": "2.0-2.9 MIL. SCORE"
       },
       "44": {
-        "start": 1764,
+        "start": 1776,
         "encoding": "bcd",
         "length": 3,
         "label": "3.0-3.9 MIL. SCORE"
       },
       "45": {
-        "start": 1768,
+        "start": 1780,
         "encoding": "bcd",
         "length": 3,
         "label": "4.0-5.9 MIL. SCORE"
       },
       "46": {
-        "start": 1772,
+        "start": 1784,
         "encoding": "bcd",
         "length": 3,
         "label": "6.0-7.9 MIL. SCORE"
       },
       "47": {
-        "start": 1776,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "8.0-99.9 MIL. SCORE"
-      },
-      "48": {
-        "start": 1780,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "FIRST REPLAY IS"
-      },
-      "49": {
-        "start": 1784,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "AVG. GAME 200 MIN."
-      },
-      "50": {
         "start": 1788,
         "encoding": "bcd",
         "length": 3,
-        "label": "HI. SCR. 3 CREDITS"
+        "label": "8.0-99.9 MIL. SCORE"
       }
     }
   }

--- a/maps/williams/system11/taxi_l4.nv.json
+++ b/maps/williams/system11/taxi_l4.nv.json
@@ -3,7 +3,8 @@
     "Compiled by Francis De Brabandere.",
     "Taxi (Williams 1988)",
     "https://www.ipdb.org/machine.cgi?id=2505",
-    "Williams System 11B"
+    "Williams System 11B",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
   "_license": "GNU Lesser General Public License v3.0",
@@ -13,7 +14,7 @@
     "taxi_l4"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "game_state": {
     "credits": {
       "label": "Credits",

--- a/maps/williams/system11/tsptr_l3.nv.json
+++ b/maps/williams/system11/tsptr_l3.nv.json
@@ -1,7 +1,9 @@
 {
   "_notes": [
-    "Transporter the Rescue (Bally, 1989, System 11B)",
-    "TODO: find au-51, verify last_game offsets, list values for adj-11, verify adj-50"
+    "Transporter the Rescue (Bally 1989)",
+    "https://www.ipdb.org/machine.cgi?id=2630",
+    "Williams System 11B",
+    "TODO: verify last_game offsets, list values for adj-11, verify adj-50"
   ],
   "_copyright": "Copyright (C) 2018 by Tom Collins <tom@tomlogic.com>",
   "_license": "GNU Lesser General Public License v3.0",

--- a/maps/williams/system11/tsptr_l3.nv.json
+++ b/maps/williams/system11/tsptr_l3.nv.json
@@ -987,12 +987,6 @@
         "length": 3,
         "label": "10-99 Mil. Score"
       },
-      "51": {
-        "start": 1867,
-        "encoding": "bcd",
-        "length": 3,
-        "label": "Av. Min. Game Time"
-      },
       "52": {
         "start": 1493,
         "encoding": "bcd",
@@ -1019,6 +1013,12 @@
       "end": 1802,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1493,
+      "end": 1504,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ]
 }

--- a/maps/williams/system11/whirl_l3.nv.json
+++ b/maps/williams/system11/whirl_l3.nv.json
@@ -1,7 +1,11 @@
 {
   "_notes": [
     "Compiled by HorsePin",
-    "added _char_map for mapping intials (Tom Collins)"
+    "Whirlwind (Williams 1990)",
+    "https://www.ipdb.org/machine.cgi?id=2765",
+    "Williams System 11B",
+    "2022-12     : added _char_map for mapping intials (Tom Collins)",
+    "2025-03 v0.2: Tom Collins added audits"
   ],
   "_copyright": "Copyright (C) 2022 https://github.com/horseyhorsey",
   "_license": "GNU Lesser General Public License v3.0",
@@ -11,7 +15,7 @@
     "whirl_l3"
   ],
   "_fileformat": 0.1,
-  "_version": 0.1,
+  "_version": 0.2,
   "_char_map": " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "game_state": {
     "credits": {

--- a/maps/williams/system11/whirl_l3.nv.json
+++ b/maps/williams/system11/whirl_l3.nv.json
@@ -135,6 +135,12 @@
       "end": 1840,
       "groupings": 4,
       "label": "Audits"
+    },
+    {
+      "start": 1454,
+      "end": 1465,
+      "groupings": 4,
+      "label": "Audits Continued"
     }
   ],
   "audits": {
@@ -275,7 +281,7 @@
         "start": 1757,
         "encoding": "bcd",
         "length": 3,
-        "label": "MILLION PLUS?S"
+        "label": "MILLION PLUS'S"
       },
       "30": {
         "start": 1761,
@@ -402,6 +408,24 @@
         "encoding": "bcd",
         "length": 3,
         "label": "10-99.9 MIL. SCORE"
+      },
+      "52": {
+        "start": 1454,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT DRAINS"
+      },
+      "53": {
+        "start": 1458,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT DRAINS"
+      },
+      "54": {
+        "start": 1462,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES ON"
       }
     }
   }

--- a/maps/williams/system11/whirl_l3.nv.json
+++ b/maps/williams/system11/whirl_l3.nv.json
@@ -136,5 +136,273 @@
       "groupings": 4,
       "label": "Audits"
     }
-  ]
+  ],
+  "audits": {
+    "Audits": {
+      "01": {
+        "start": 1669,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "LEFT COINS"
+      },
+      "02": {
+        "start": 1673,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CENTER COINS"
+      },
+      "03": {
+        "start": 1677,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "RIGHT COINS"
+      },
+      "04": {
+        "start": 1681,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "PAID CREDITS"
+      },
+      "05": {
+        "start": 1685,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL PLAYS"
+      },
+      "06": {
+        "start": 1689,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "TOTAL FREE"
+      },
+      "08": {
+        "start": 1693,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY AWARDS"
+      },
+      "10": {
+        "start": 1697,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SPECIAL AWARDS"
+      },
+      "12": {
+        "start": 1701,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MATCH AWARDS"
+      },
+      "13": {
+        "start": 1705,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.T.D. CREDITS"
+      },
+      "15": {
+        "start": 1709,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "EXTRA BALLS"
+      },
+      "18": {
+        "start": 1713,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MINUTES OF PLAY"
+      },
+      "19": {
+        "start": 1717,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BALLS PLAYED"
+      },
+      "20": {
+        "start": 1721,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY1 AWARDS"
+      },
+      "21": {
+        "start": 1725,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY2 AWARDS"
+      },
+      "22": {
+        "start": 1729,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY3 AWARDS"
+      },
+      "23": {
+        "start": 1733,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "REPLAY4 AWARDS"
+      },
+      "24": {
+        "start": 1737,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 PLAYER GAMES"
+      },
+      "25": {
+        "start": 1741,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2 PLAYER GAMES"
+      },
+      "26": {
+        "start": 1745,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3 PLAYER GAMES"
+      },
+      "27": {
+        "start": 1749,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4 PLAYER GAMES"
+      },
+      "28": {
+        "start": 1753,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "BURN-IN CYCLES"
+      },
+      "29": {
+        "start": 1757,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "MILLION PLUS?S"
+      },
+      "30": {
+        "start": 1761,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1 MILLION SHOT"
+      },
+      "31": {
+        "start": 1765,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "ALL MULTIBALLS"
+      },
+      "32": {
+        "start": 1769,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "QUICK MULTIBALLS"
+      },
+      "33": {
+        "start": 1773,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CELLAR MULTIBALL"
+      },
+      "34": {
+        "start": 1777,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1ST EX. BALL LIT"
+      },
+      "35": {
+        "start": 1781,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2ND EX. BALL LIT"
+      },
+      "36": {
+        "start": 1785,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CELLAR E.BALL LIT"
+      },
+      "37": {
+        "start": 1789,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "CELLAR SPEC. AWD."
+      },
+      "38": {
+        "start": 1793,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "SUPER CELLAR AWD."
+      },
+      "39": {
+        "start": 1889,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "H.S.RESET COUNTER"
+      },
+      "40": {
+        "start": 1797,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.0-0.4 MIL. SCORE"
+      },
+      "41": {
+        "start": 1801,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "0.5-0.9 MIL. SCORE"
+      },
+      "42": {
+        "start": 1805,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.0-1.4 MIL. SCORE"
+      },
+      "43": {
+        "start": 1809,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "1.5-1.9 MIL. SCORE"
+      },
+      "44": {
+        "start": 1813,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "2.0-2.9 MIL. SCORE"
+      },
+      "45": {
+        "start": 1817,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "3.0-3.9 MIL. SCORE"
+      },
+      "46": {
+        "start": 1821,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "4.0-4.9 MIL. SCORE"
+      },
+      "47": {
+        "start": 1825,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "5.0-5.9 MIL. SCORE"
+      },
+      "48": {
+        "start": 1829,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "6.0-7.9 MIL. SCORE"
+      },
+      "49": {
+        "start": 1833,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "8.0-9.9 MIL. SCORE"
+      },
+      "50": {
+        "start": 1837,
+        "encoding": "bcd",
+        "length": 3,
+        "label": "10-99.9 MIL. SCORE"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Extracting audit names from some ROMs, but need to verify memory offsets.

I wanted to get this out for others to see.  I plan to write a Python script to write sequential values to each audit position in a `.nv` files for each of these targets, and then view them in PinMAME to see if I have the correct locations for each audit.