### PR TITLE
fix: williams checksum8 ranges not divisible by groupings

### DIFF
--- a/maps/williams/system11/bbnny_l2.nv.json
+++ b/maps/williams/system11/bbnny_l2.nv.json
@@ -128,7 +128,7 @@
     },
     {
       "start": 1519,
-      "end": 1527,
+      "end": 1526,
       "groupings": 4,
       "label": "Audits Continued"
     }

--- a/maps/williams/system11/bcats_l5.nv.json
+++ b/maps/williams/system11/bcats_l5.nv.json
@@ -126,7 +126,7 @@
     },
     {
       "start": 1488,
-      "end": 1516,
+      "end": 1515,
       "groupings": 4,
       "label": "Audits Continued"
     }


### PR DESCRIPTION
My lib complains about these

> Error: Custom { kind: InvalidData, error: "Failed to resolve: testdata/bbnny_l2.nv: Inclusive range [1519 - 1527] (9 elements) is not divisible by groupings 4" }

@tomlogic maybe you can do the same in python?