### PR TITLE
d2_l2: fix audit 35 encoding (bcd->int)

### DIFF
--- a/maps/williams/wpc/dw_l2.nv.json
+++ b/maps/williams/wpc/dw_l2.nv.json
@@ -621,7 +621,7 @@
         "label": "1st Replay Level",
         "suffix": "M",
         "start": 7354,
-        "encoding": "bcd",
+        "encoding": "int",
         "length": 2
       },
       "36": {


### PR DESCRIPTION
All WPC audits are 2-byte integers.