### PR TITLE
wms/sys7: fix aud13 size and offset of aud14-17

### DIFF
--- a/maps/williams/system7/generic.nv.json
+++ b/maps/williams/system7/generic.nv.json
@@ -131,30 +131,30 @@
       "13": {
         "label": "HSTD Credits",
         "start": 78,
-        "length": 2,
+        "length": 4,
         "encoding": "bcd"
       },
       "14": {
         "label": "Replay 1 Awarded",
-        "start": 80,
+        "start": 82,
         "length": 4,
         "encoding": "bcd"
       },
       "15": {
         "label": "Replay 2 Awarded",
-        "start": 84,
+        "start": 86,
         "length": 4,
         "encoding": "bcd"
       },
       "16": {
         "label": "Replay 3 Awarded",
-        "start": 88,
+        "start": 90,
         "length": 4,
         "encoding": "bcd"
       },
       "17": {
         "label": "Replay 4 Awarded",
-        "start": 92,
+        "start": 94,
         "length": 4,
         "encoding": "bcd"
       }

--- a/maps/williams/system7/lsrcu_l2.nv.json
+++ b/maps/williams/system7/lsrcu_l2.nv.json
@@ -138,30 +138,30 @@
       "13": {
         "label": "HSTD Credits",
         "start": 78,
-        "length": 2,
+        "length": 4,
         "encoding": "bcd"
       },
       "14": {
         "label": "Replay 1 Awarded",
-        "start": 80,
+        "start": 82,
         "length": 4,
         "encoding": "bcd"
       },
       "15": {
         "label": "Replay 2 Awarded",
-        "start": 84,
+        "start": 86,
         "length": 4,
         "encoding": "bcd"
       },
       "16": {
         "label": "Replay 3 Awarded",
-        "start": 88,
+        "start": 90,
         "length": 4,
         "encoding": "bcd"
       },
       "17": {
         "label": "Replay 4 Awarded",
-        "start": 92,
+        "start": 94,
         "length": 4,
         "encoding": "bcd"
       }


### PR DESCRIPTION
Jess Askey's documents had the wrong offsets for audits 14-17 (count of replay awards at each of 4 levels), which caused me to short the HSTD credits audit by 2 bytes to avoid overlap.