### PR TITLE
wms/sys7: remove min/max on adj41 (max EB) #112

### DIFF
--- a/maps/williams/system7/generic.nv.json
+++ b/maps/williams/system7/generic.nv.json
@@ -371,9 +371,7 @@
         "label": "Maximum Extra Balls",
         "start": 169,
         "length": 2,
-        "encoding": "bcd",
-        "min": 0,
-        "max": 4
+        "encoding": "bcd"
       }
     },
     "Game Adjustments": {

--- a/maps/williams/system7/lsrcu_l2.nv.json
+++ b/maps/williams/system7/lsrcu_l2.nv.json
@@ -342,9 +342,7 @@
         "label": "Maximum Extra Balls",
         "start": 169,
         "length": 2,
-        "encoding": "bcd",
-        "min": 0,
-        "max": 4
+        "encoding": "bcd"
       }
     },
     "Game Adjustments": {


### PR DESCRIPTION
Value I had for max was the default value.  Adjustment supports full range of values for the given configuration (2 BCD nibbles = 00-99).