### PR TITLE
sorcr_l2: Add `encoding` field to Drop Target Blink Interval

### DIFF
--- a/maps/williams/system9/sorcr_l2.map.json
+++ b/maps/williams/system9/sorcr_l2.map.json
@@ -485,6 +485,7 @@
         "label": "Drop Target Blink Interval",
         "_notes": "0=fast, 9=slow",
         "start": "0x792",
+        "encoding": "bcd",
         "min": 0,
         "max": 9,
         "default": 5


### PR DESCRIPTION
`encoding` is required

https://github.com/tomlogic/pinmame-nvram-maps/blob/7afd9795c32ca8645716515a07c4eb3ba9aa0bfd/README.md?plain=1#L215