### PR TITLE
Support 10-letter high score names in SAM maps 

### DIFF
--- a/maps/stern/sam/acd_170h.map.json
+++ b/maps/stern/sam/acd_170h.map.json
@@ -14,7 +14,8 @@
       "initials": {
         "start": "0x021037FC",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103814",
@@ -27,7 +28,8 @@
       "initials": {
         "start": "0x02103820",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103838",
@@ -40,7 +42,8 @@
       "initials": {
         "start": "0x02103844",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x0210385C",
@@ -53,7 +56,8 @@
       "initials": {
         "start": "0x02103868",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103880",
@@ -66,7 +70,8 @@
       "initials": {
         "start": "0x0210388C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021038A4",
@@ -81,7 +86,8 @@
       "initials": {
         "start": "0x021038B0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "counter": {
         "start": "0x021038C8",
@@ -94,7 +100,8 @@
       "initials": {
         "start": "0x021038D4",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021038EC",
@@ -107,7 +114,8 @@
       "initials": {
         "start": "0x021038F8",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103910",
@@ -120,7 +128,8 @@
       "initials": {
         "start": "0x0210391C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103934",
@@ -133,7 +142,8 @@
       "initials": {
         "start": "0x02103940",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103958",
@@ -146,7 +156,8 @@
       "initials": {
         "start": "0x02103964",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x0210397C",
@@ -159,7 +170,8 @@
       "initials": {
         "start": "0x02103988",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021039A0",
@@ -172,7 +184,8 @@
       "initials": {
         "start": "0x021039AC",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021039C4",
@@ -185,7 +198,8 @@
       "initials": {
         "start": "0x021039D0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021039E8",
@@ -198,7 +212,8 @@
       "initials": {
         "start": "0x021039F4",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103A0C",
@@ -211,7 +226,8 @@
       "initials": {
         "start": "0x02103A18",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103A30",
@@ -224,7 +240,8 @@
       "initials": {
         "start": "0x02103A3C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103A54",
@@ -237,7 +254,8 @@
       "initials": {
         "start": "0x02103A60",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103A78",
@@ -250,7 +268,8 @@
       "initials": {
         "start": "0x02103A84",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103A9C",
@@ -263,7 +282,8 @@
       "initials": {
         "start": "0x02103ACC",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103AE4",

--- a/maps/stern/sam/acd_170h.map.json
+++ b/maps/stern/sam/acd_170h.map.json
@@ -1,7 +1,7 @@
 {
   "_fileformat": 0.7,
   "_metadata": {
-    "version": 1,
+    "version": 2,
     "license": "GNU Lesser General Public License v3.0",
     "platform": "stern-sam",
     "roms": [

--- a/maps/stern/sam/avs_170.map.json
+++ b/maps/stern/sam/avs_170.map.json
@@ -15,7 +15,8 @@
       "initials": {
         "start": "0x02102F80",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102F98",
@@ -28,7 +29,8 @@
       "initials": {
         "start": "0x02102FA0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102FB8",
@@ -41,7 +43,8 @@
       "initials": {
         "start": "0x02102FC0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102FD8",
@@ -54,7 +57,8 @@
       "initials": {
         "start": "0x02102FE0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102FF8",
@@ -67,7 +71,8 @@
       "initials": {
         "start": "0x02103000",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103018",

--- a/maps/stern/sam/avs_170.map.json
+++ b/maps/stern/sam/avs_170.map.json
@@ -1,7 +1,7 @@
 {
   "_fileformat": 0.7,
   "_metadata": {
-    "version": 1,
+    "version": 2,
     "license": "GNU Lesser General Public License v3.0",
     "platform": "stern-sam",
     "roms": [

--- a/maps/stern/sam/bdk_294.map.json
+++ b/maps/stern/sam/bdk_294.map.json
@@ -14,7 +14,8 @@
       "initials": {
         "start": "0x02102B00",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102B18",
@@ -27,7 +28,8 @@
       "initials": {
         "start": "0x02102B20",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102B38",
@@ -40,7 +42,8 @@
       "initials": {
         "start": "0x02102B40",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102B58",
@@ -53,7 +56,8 @@
       "initials": {
         "start": "0x02102B60",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102B78",
@@ -66,7 +70,8 @@
       "initials": {
         "start": "0x02102B80",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102B98",
@@ -81,7 +86,8 @@
       "initials": {
         "start": "0x02102BA0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102BB8",
@@ -94,7 +100,8 @@
       "initials": {
         "start": "0x02102BC0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102BD8",
@@ -107,7 +114,8 @@
       "initials": {
         "start": "0x02102BE0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102BF8",

--- a/maps/stern/sam/bdk_294.map.json
+++ b/maps/stern/sam/bdk_294.map.json
@@ -1,7 +1,7 @@
 {
   "_fileformat": 0.7,
   "_metadata": {
-    "version": 1,
+    "version": 2,
     "license": "GNU Lesser General Public License v3.0",
     "platform": "stern-sam",
     "roms": [

--- a/maps/stern/sam/mtl_180h.map.json
+++ b/maps/stern/sam/mtl_180h.map.json
@@ -14,7 +14,8 @@
       "initials": {
         "start": "0x02103724",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x0210373C",
@@ -27,7 +28,8 @@
       "initials": {
         "start": "0x02103748",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103760",
@@ -40,7 +42,8 @@
       "initials": {
         "start": "0x0210376C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103784",
@@ -53,7 +56,8 @@
       "initials": {
         "start": "0x02103790",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021037A8",
@@ -66,7 +70,8 @@
       "initials": {
         "start": "0x021037B4",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021037CC",
@@ -81,7 +86,8 @@
       "initials": {
         "start": "0x021037D8",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "counter": {
         "start": "0x021037F0",
@@ -94,7 +100,8 @@
       "initials": {
         "start": "0x021038D4",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021038EC",
@@ -107,7 +114,8 @@
       "initials": {
         "start": "0x021038B0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021038C8",
@@ -120,7 +128,8 @@
       "initials": {
         "start": "0x021038F8",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103910",
@@ -133,7 +142,8 @@
       "initials": {
         "start": "0x02103820",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103838",
@@ -146,7 +156,8 @@
       "initials": {
         "start": "0x0210388C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021038A4",
@@ -159,7 +170,8 @@
       "initials": {
         "start": "0x021037FC",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103814",
@@ -172,7 +184,8 @@
       "initials": {
         "start": "0x02103868",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103880",
@@ -185,7 +198,8 @@
       "initials": {
         "start": "0x02103844",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x0210385C",
@@ -198,7 +212,8 @@
       "initials": {
         "start": "0x0210391C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103934",

--- a/maps/stern/sam/mtl_180h.map.json
+++ b/maps/stern/sam/mtl_180h.map.json
@@ -1,7 +1,7 @@
 {
   "_fileformat": 0.7,
   "_metadata": {
-    "version": 1,
+    "version": 2,
     "license": "GNU Lesser General Public License v3.0",
     "platform": "stern-sam",
     "roms": [

--- a/maps/stern/sam/smanve_101.map.json
+++ b/maps/stern/sam/smanve_101.map.json
@@ -15,7 +15,8 @@
       "initials": {
         "start": "0x02102b80",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102b98",
@@ -28,7 +29,8 @@
       "initials": {
         "start": "0x02102ba0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102bb8",
@@ -41,7 +43,8 @@
       "initials": {
         "start": "0x02102bc0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102bd8",
@@ -54,7 +57,8 @@
       "initials": {
         "start": "0x02102be0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102bf8",
@@ -67,7 +71,8 @@
       "initials": {
         "start": "0x02102c00",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102c18",
@@ -82,7 +87,8 @@
       "initials": {
         "start": "0x02102c20",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "counter": {
         "start": "0x02102c38",
@@ -95,7 +101,8 @@
       "initials": {
         "start": "0x02102c40",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "counter": {
         "start": "0x02102c5a",
@@ -108,7 +115,8 @@
       "initials": {
         "start": "0x02102c60",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "counter": {
         "start": "0x02102c78",
@@ -121,7 +129,8 @@
       "initials": {
         "start": "0x02102c80",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102c98",
@@ -134,7 +143,8 @@
       "initials": {
         "start": "0x02102ca0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102cb8",
@@ -147,7 +157,8 @@
       "initials": {
         "start": "0x02102cc0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102cd8",
@@ -160,7 +171,8 @@
       "initials": {
         "start": "0x02102ce0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102cf8",

--- a/maps/stern/sam/smanve_101.map.json
+++ b/maps/stern/sam/smanve_101.map.json
@@ -1,7 +1,7 @@
 {
   "_fileformat": 0.7,
   "_metadata": {
-    "version": 1,
+    "version": 2,
     "license": "GNU Lesser General Public License v3.0",
     "platform": "stern-sam",
     "roms": [

--- a/maps/stern/sam/trn_174h.map.json
+++ b/maps/stern/sam/trn_174h.map.json
@@ -14,7 +14,8 @@
       "initials": {
         "start": "0x02102BD8",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102BF0",
@@ -27,7 +28,8 @@
       "initials": {
         "start": "0x02102BF8",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102C10",
@@ -40,7 +42,8 @@
       "initials": {
         "start": "0x02102C18",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102C30",
@@ -53,7 +56,8 @@
       "initials": {
         "start": "0x02102C38",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102C50",
@@ -66,7 +70,8 @@
       "initials": {
         "start": "0x02102C58",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02102C70",

--- a/maps/stern/sam/trn_174h.map.json
+++ b/maps/stern/sam/trn_174h.map.json
@@ -1,7 +1,7 @@
 {
   "_fileformat": 0.7,
   "_metadata": {
-    "version": 1,
+    "version": 2,
     "license": "GNU Lesser General Public License v3.0",
     "platform": "stern-sam",
     "roms": [

--- a/maps/stern/sam/twd_160h.map.json
+++ b/maps/stern/sam/twd_160h.map.json
@@ -1,7 +1,7 @@
 {
   "_fileformat": 0.7,
   "_metadata": {
-    "version": 1,
+    "version": 2,
     "license": "GNU Lesser General Public License v3.0",
     "platform": "stern-sam",
     "roms": [

--- a/maps/stern/sam/twd_160h.map.json
+++ b/maps/stern/sam/twd_160h.map.json
@@ -14,7 +14,8 @@
       "initials": {
         "start": "0x02103714",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x0210372C",
@@ -27,7 +28,8 @@
       "initials": {
         "start": "0x02103738",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103750",
@@ -40,7 +42,8 @@
       "initials": {
         "start": "0x0210375C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103774",
@@ -53,7 +56,8 @@
       "initials": {
         "start": "0x02103780",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103798",
@@ -66,7 +70,8 @@
       "initials": {
         "start": "0x021037A4",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021037BC",
@@ -81,7 +86,8 @@
       "initials": {
         "start": "0x021037C8",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "counter": {
         "start": "0x021037E0",
@@ -94,7 +100,8 @@
       "initials": {
         "start": "0x021037EC",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "counter": {
         "start": "0x02103804",
@@ -107,7 +114,8 @@
       "initials": {
         "start": "0x02103810",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103828",
@@ -120,7 +128,8 @@
       "initials": {
         "start": "0x02103834",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x0210384C",
@@ -133,7 +142,8 @@
       "initials": {
         "start": "0x02103858",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103870",
@@ -146,7 +156,8 @@
       "initials": {
         "start": "0x0210387C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103894",
@@ -159,7 +170,8 @@
       "initials": {
         "start": "0x021038A0",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021038B8",
@@ -172,7 +184,8 @@
       "initials": {
         "start": "0x021038C4",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021038DC",
@@ -185,7 +198,8 @@
       "initials": {
         "start": "0x021038E8",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103900",
@@ -198,7 +212,8 @@
       "initials": {
         "start": "0x0210390C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103924",
@@ -211,7 +226,8 @@
       "initials": {
         "start": "0x02103930",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103948",
@@ -224,7 +240,8 @@
       "initials": {
         "start": "0x02103954",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x0210396C",
@@ -237,7 +254,8 @@
       "initials": {
         "start": "0x02103978",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x02103990",
@@ -250,7 +268,8 @@
       "initials": {
         "start": "0x0210399C",
         "encoding": "ch",
-        "length": 3
+        "null": "terminate",
+        "length": 11
       },
       "score": {
         "start": "0x021039B4",


### PR DESCRIPTION
This follow-up to #147 updates the newly added Stern SAM maps to support 10-letter high score / champion names.

I checked against our "old-school" NVRAMs for these ROMs to confirm the new null-terminated 11-byte name fields still decode the existing 3-character entries correctly. 