### PR TITLE
fix(disco_l1): correct Play adjustment min to 1

### DIFF
--- a/maps/williams/system3/disco_l1.map.json
+++ b/maps/williams/system3/disco_l1.map.json
@@ -4,7 +4,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 2,
+    "version": 3,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-system4",
@@ -220,7 +220,7 @@
           "n/a",
           "no extra ball (1 & 2 together)"
         ],
-        "min": 2,
+        "min": 1,
         "max": 4
       },
       "08": {


### PR DESCRIPTION
The "Play" adjustment listed min 2, but index 1 ("normal (1 & 2 together)") is a real setting; only index 0 is the reserved "n/a" slot. Sibling System 3 maps with a real value at index 1 (httip_l1, wldcp_l1) use min 1, while cntct_l1 legitimately uses min 2 because it pads both index 0 and 1 with "n/a".

This was flagged when a real disco_l1 dump decoded index 1 and tripped a spurious "out of range" warning. Bump map version to 3.