### PR TITLE
feat(wpc): mark unset Volume as n/a via special_values

### DIFF
--- a/maps/williams/wpc/afm_11.map.json
+++ b/maps/williams/wpc/afm_11.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -112,7 +112,10 @@
       "start": 7460,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/afm_113.map.json
+++ b/maps/williams/wpc/afm_113.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": [
       "Copyright (C) 2016 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -69,7 +69,10 @@
       "start": 7500,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/bop_l7.map.json
+++ b/maps/williams/wpc/bop_l7.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -78,7 +78,10 @@
       "start": 7414,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/br_l4.map.json
+++ b/maps/williams/wpc/br_l4.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -79,7 +79,10 @@
       "start": 7336,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/cc_13.map.json
+++ b/maps/williams/wpc/cc_13.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -79,7 +79,10 @@
       "start": 7445,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/cftbl_l4.map.json
+++ b/maps/williams/wpc/cftbl_l4.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -82,7 +82,10 @@
       "start": 7396,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/congo_21.map.json
+++ b/maps/williams/wpc/congo_21.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -80,7 +80,10 @@
       "start": 7460,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "current_player": {
       "label": "Current Player",

--- a/maps/williams/wpc/corv_21.map.json
+++ b/maps/williams/wpc/corv_21.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -75,7 +75,10 @@
       "start": 7520,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/cp_16.map.json
+++ b/maps/williams/wpc/cp_16.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -77,7 +77,10 @@
       "start": 7510,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/cv_14.map.json
+++ b/maps/williams/wpc/cv_14.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -76,7 +76,10 @@
       "start": 7615,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/cv_20h.map.json
+++ b/maps/williams/wpc/cv_20h.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -85,7 +85,10 @@
       "start": 7631,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/dh_lx2.map.json
+++ b/maps/williams/wpc/dh_lx2.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2022 https://github.com/horseyhorsey",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -63,7 +63,10 @@
       "start": 7460,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/dm_h6.map.json
+++ b/maps/williams/wpc/dm_h6.map.json
@@ -5,7 +5,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": [
       "Copyright (C) 2015 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -75,7 +75,10 @@
       "start": 7369,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/dm_lx4.map.json
+++ b/maps/williams/wpc/dm_lx4.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2015, 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -74,7 +74,10 @@
       "start": 7329,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/dm_pa2.map.json
+++ b/maps/williams/wpc/dm_pa2.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -114,7 +114,10 @@
       "start": 7329,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/drac_l1.map.json
+++ b/maps/williams/wpc/drac_l1.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2022 https://github.com/horseyhorsey",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -66,7 +66,10 @@
       "start": 7506,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/dw_l2.map.json
+++ b/maps/williams/wpc/dw_l2.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2018 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -268,7 +268,10 @@
       "start": 7506,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/fh_905h.map.json
+++ b/maps/williams/wpc/fh_905h.map.json
@@ -9,7 +9,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": [
       "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -67,7 +67,10 @@
       "start": 7334,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/fh_l3.map.json
+++ b/maps/williams/wpc/fh_l3.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -71,7 +71,10 @@
       "start": 7317,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/fh_l9.map.json
+++ b/maps/williams/wpc/fh_l9.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": [
       "Copyright (C) 2016 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -68,7 +68,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/fs_lx5.map.json
+++ b/maps/williams/wpc/fs_lx5.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -79,7 +79,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/ft_l4.map.json
+++ b/maps/williams/wpc/ft_l4.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -112,7 +112,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/ft_l5.map.json
+++ b/maps/williams/wpc/ft_l5.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -78,7 +78,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "current_player": {
       "label": "Current Player",

--- a/maps/williams/wpc/ft_p4.map.json
+++ b/maps/williams/wpc/ft_p4.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -113,7 +113,10 @@
       "start": 7304,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/gi_l9.map.json
+++ b/maps/williams/wpc/gi_l9.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -76,7 +76,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/gw_l2.map.json
+++ b/maps/williams/wpc/gw_l2.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -111,7 +111,10 @@
       "start": 7304,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/gw_l5.map.json
+++ b/maps/williams/wpc/gw_l5.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -79,7 +79,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/hd_l3.map.json
+++ b/maps/williams/wpc/hd_l3.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": [
       "Copyright (C) 2016 by Horsepin",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -66,7 +66,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/hurr_l2.map.json
+++ b/maps/williams/wpc/hurr_l2.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -82,7 +82,10 @@
       "start": 7304,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "current_player": {
       "label": "Current Player",

--- a/maps/williams/wpc/i500_11r.map.json
+++ b/maps/williams/wpc/i500_11r.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -77,7 +77,10 @@
       "start": 7521,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/ij_l7.map.json
+++ b/maps/williams/wpc/ij_l7.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -88,7 +88,10 @@
       "start": 7603,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/jb_10r.map.json
+++ b/maps/williams/wpc/jb_10r.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -78,7 +78,10 @@
       "start": 7584,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/jd_l1.map.json
+++ b/maps/williams/wpc/jd_l1.map.json
@@ -11,7 +11,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -93,7 +93,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/jd_l7.map.json
+++ b/maps/williams/wpc/jd_l7.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -77,7 +77,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/jm_12r.map.json
+++ b/maps/williams/wpc/jm_12r.map.json
@@ -5,7 +5,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": [
       "Copyright (C) 2015 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -66,7 +66,10 @@
       "start": 7330,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/jy_12.map.json
+++ b/maps/williams/wpc/jy_12.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -78,7 +78,10 @@
       "start": 7450,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/mb_10.map.json
+++ b/maps/williams/wpc/mb_10.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -75,7 +75,10 @@
       "start": 7365,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/mb_106.map.json
+++ b/maps/williams/wpc/mb_106.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -79,7 +79,10 @@
       "start": 7375,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "game_over": {
       "label": "Game Over",

--- a/maps/williams/wpc/mm_10.map.json
+++ b/maps/williams/wpc/mm_10.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": [
       "Copyright (C) 2016 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -69,7 +69,10 @@
       "start": 7517,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/mm_109.map.json
+++ b/maps/williams/wpc/mm_109.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": [
       "Copyright (C) 2016 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -70,7 +70,10 @@
       "start": 7525,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/nbaf_31.map.json
+++ b/maps/williams/wpc/nbaf_31.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": [
       "Copyright (C) 2024 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -65,7 +65,10 @@
       "start": 7329,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/nf_22.map.json
+++ b/maps/williams/wpc/nf_22.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 8,
+    "version": 9,
     "copyright": [
       "Copyright (C) 2016 by Dave Horsepin <horse@horsesoft.uk>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -67,7 +67,10 @@
       "start": 7470,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/nf_23.map.json
+++ b/maps/williams/wpc/nf_23.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 7,
+    "version": 8,
     "copyright": [
       "Copyright (C) 2016 by Dave Horsepin <horse@horsesoft.uk>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -64,7 +64,10 @@
       "start": 7470,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/ngg_13.map.json
+++ b/maps/williams/wpc/ngg_13.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -75,7 +75,10 @@
       "start": 7428,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "current_player": {
       "label": "Current Player",

--- a/maps/williams/wpc/pop_lx5.map.json
+++ b/maps/williams/wpc/pop_lx5.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -71,7 +71,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/pz_f4.map.json
+++ b/maps/williams/wpc/pz_f4.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -70,7 +70,10 @@
       "start": 7304,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/pz_l1.map.json
+++ b/maps/williams/wpc/pz_l1.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -111,7 +111,10 @@
       "start": 7300,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/pz_l3.map.json
+++ b/maps/williams/wpc/pz_l3.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -72,7 +72,10 @@
       "start": 7303,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/rs_l6.map.json
+++ b/maps/williams/wpc/rs_l6.map.json
@@ -13,7 +13,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 7,
+    "version": 8,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -89,7 +89,10 @@
       "start": 7330,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/rs_pa2.map.json
+++ b/maps/williams/wpc/rs_pa2.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -110,7 +110,10 @@
       "start": 7330,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/sc_091.map.json
+++ b/maps/williams/wpc/sc_091.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -72,7 +72,10 @@
       "start": 7505,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/sc_18.map.json
+++ b/maps/williams/wpc/sc_18.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -80,7 +80,10 @@
       "start": 7525,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/ss_15.map.json
+++ b/maps/williams/wpc/ss_15.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -69,7 +69,10 @@
       "start": 7571,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/sttng_l7.map.json
+++ b/maps/williams/wpc/sttng_l7.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -84,7 +84,10 @@
       "start": 7329,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/t2_l2.map.json
+++ b/maps/williams/wpc/t2_l2.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -111,7 +111,10 @@
       "start": 7300,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/t2_l8.map.json
+++ b/maps/williams/wpc/t2_l8.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -74,7 +74,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/taf_l4.map.json
+++ b/maps/williams/wpc/taf_l4.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -111,7 +111,10 @@
       "start": 7312,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/taf_l5.map.json
+++ b/maps/williams/wpc/taf_l5.map.json
@@ -11,7 +11,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -78,7 +78,10 @@
       "start": 7344,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/taf_l7.map.json
+++ b/maps/williams/wpc/taf_l7.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -72,7 +72,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/tafg_h3.map.json
+++ b/maps/williams/wpc/tafg_h3.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -111,7 +111,10 @@
       "start": 7344,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/tafg_la2.map.json
+++ b/maps/williams/wpc/tafg_la2.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -111,7 +111,10 @@
       "start": 7344,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     }
   },
   "high_scores": [

--- a/maps/williams/wpc/tafg_lx3.map.json
+++ b/maps/williams/wpc/tafg_lx3.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -72,7 +72,10 @@
       "start": 7344,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/tom_13.map.json
+++ b/maps/williams/wpc/tom_13.map.json
@@ -12,7 +12,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 7,
+    "version": 8,
     "copyright": [
       "Copyright (C) 2017 by Mike Metzger <mike@flexiblecreations.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -97,7 +97,10 @@
       "start": 7325,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/totan_14.map.json
+++ b/maps/williams/wpc/totan_14.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2022 HorsePin",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -65,7 +65,10 @@
       "start": 7584,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/ts_lx5.map.json
+++ b/maps/williams/wpc/ts_lx5.map.json
@@ -10,7 +10,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 7,
+    "version": 8,
     "copyright": [
       "Copyright (C) 2022 https://github.com/horseyhorsey",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -87,7 +87,10 @@
       "start": 7514,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/tz_92.map.json
+++ b/maps/williams/wpc/tz_92.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -74,7 +74,10 @@
       "start": 7561,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/tz_94h.map.json
+++ b/maps/williams/wpc/tz_94h.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-8K",
@@ -72,7 +72,10 @@
       "start": 7587,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/wcs_l2.map.json
+++ b/maps/williams/wpc/wcs_l2.map.json
@@ -10,7 +10,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "GNU Lesser General Public License v3.0",
     "platform": "williams-wpc-12K",
@@ -81,7 +81,10 @@
       "start": 7469,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/wd_03r.map.json
+++ b/maps/williams/wpc/wd_03r.map.json
@@ -6,7 +6,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2026 by Andre Santana <herrmirto@proton.me>"
@@ -71,7 +71,10 @@
       "start": 7450,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/wd_12.map.json
+++ b/maps/williams/wpc/wd_12.map.json
@@ -9,7 +9,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2026 by Andre Santana <herrmirto@proton.me>"
@@ -82,7 +82,10 @@
       "start": 7450,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/ww_l5.map.json
+++ b/maps/williams/wpc/ww_l5.map.json
@@ -10,7 +10,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2017 by Mike Metzger <mike@flexiblecreations.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -73,7 +73,10 @@
       "start": 7324,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",

--- a/maps/williams/wpc/ww_lh6.map.json
+++ b/maps/williams/wpc/ww_lh6.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": [
       "Copyright (C) 2024 by Francis De Brabandere <francisdb@gmail.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -61,7 +61,10 @@
       "start": 7384,
       "encoding": "int",
       "min": 0,
-      "max": 31
+      "max": 31,
+      "special_values": {
+        "255": "n/a"
+      }
     },
     "replay": {
       "label": "Replay",


### PR DESCRIPTION
WPC stores the master volume (0-31) in NVRAM only once it is adjusted via the coin-door +/- buttons; until then the byte is left blank (`0xFF` = 255). The maps then decoded that as an out-of-range value (0 <= 255 <= 31).

Add `special_values: {"255": "n/a"}` to every WPC Volume field so the unset state reads as "n/a", matching the existing convention for the Player Count field (`{"256": "n/a"}` on System 11, where offset 1 maps the same `0xFF` byte).

This is confirmed behaviour: a fresh PinMAME boot of e.g. `taf_l5` leaves the volume block blank

Bump the version of each modified map.

_One caveat: for a never-set volume the whole block is blank (0xFF), including its checksum bytes, so the volume checksum16 does not validate (0xFFFF stored vs 0xFF00 computed). The value now reads n/a, but the checksum still reports a mismatch until the volume is set on the machine (or the library learns to treat an all-0xFF block as "uninitialized")._